### PR TITLE
Landing: swarm chat dock, copy cleanup, agent viz + motion

### DIFF
--- a/neufin-web/app/dashboard/page.tsx
+++ b/neufin-web/app/dashboard/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Link from 'next/link'
+import { motion } from 'framer-motion'
 import { Loader2 } from 'lucide-react'
 import { usePortfolioData } from '@/hooks/usePortfolioData'
 import { GraphicPlaceholder } from '@/components/GraphicPlaceholder'
@@ -99,14 +100,21 @@ export default function DashboardPage() {
               </Link>
             </div>
             <div className="relative hidden min-h-[280px] overflow-hidden bg-gradient-to-br from-[#E0F7FA] to-[#F0FDF4] lg:block">
-              <GraphicPlaceholder
-                src="/graphics/ic-report-preview.png"
-                alt="IC Report Preview"
-                fill
-                sizes="(min-width: 1024px) 40vw, 100vw"
-                className="opacity-90"
-                label="IC Report — Add ic-report-preview.png to public/graphics/"
-              />
+              <motion.div
+                className="absolute inset-0"
+                initial={{ opacity: 0, x: 28 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ duration: 0.65, ease: [0.22, 1, 0.36, 1] }}
+              >
+                <GraphicPlaceholder
+                  src="/graphics/ic-report-preview.png"
+                  alt="IC Report Preview"
+                  fill
+                  sizes="(min-width: 1024px) 40vw, 100vw"
+                  className="opacity-90"
+                  label="IC Report — Add ic-report-preview.png to public/graphics/"
+                />
+              </motion.div>
             </div>
           </div>
         </div>

--- a/neufin-web/app/globals.css
+++ b/neufin-web/app/globals.css
@@ -822,16 +822,39 @@ span:not(.badge):not(.chip) {
     inset 0 1px 0 rgba(255, 255, 255, 0.05);
 }
 
-/* ── Light glassmorphism card (landing hero overlays) ── */
+/* ── Light glassmorphism card (landing hero overlays, product demo chat) ── */
 .glass-card-light {
   background: rgba(255, 255, 255, 0.85);
-  border: 1px solid rgba(226, 232, 240, 0.8);
+  border: 1px solid rgba(30, 184, 204, 0.22);
   border-radius: 14px;
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
   box-shadow:
     0 4px 24px rgba(0, 0, 0, 0.06),
     inset 0 1px 0 rgba(255, 255, 255, 0.9);
+}
+
+@keyframes landing-grid-shift {
+  0% {
+    background-position: 0 0;
+  }
+  100% {
+    background-position: 48px 48px;
+  }
+}
+
+.landing-animated-grid {
+  background-image:
+    linear-gradient(rgba(15, 23, 42, 0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(15, 23, 42, 0.04) 1px, transparent 1px);
+  background-size: 48px 48px;
+  animation: landing-grid-shift 48s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .landing-animated-grid {
+    animation: none;
+  }
 }
 
 /* Landing hero — refined glass floating badges */

--- a/neufin-web/components/GraphicPlaceholder.tsx
+++ b/neufin-web/components/GraphicPlaceholder.tsx
@@ -8,6 +8,8 @@ type Base = {
   alt: string
   className?: string
   label: string
+  /** Defaults to cover; use contain for large background watermarks. */
+  objectFit?: 'cover' | 'contain'
 }
 
 type GraphicPlaceholderProps =
@@ -16,7 +18,7 @@ type GraphicPlaceholderProps =
 
 export function GraphicPlaceholder(props: GraphicPlaceholderProps) {
   const [error, setError] = useState(false)
-  const { src, alt, className = '', label } = props
+  const { src, alt, className = '', label, objectFit = 'cover' } = props
 
   if (error) {
     if ('fill' in props && props.fill) {
@@ -49,7 +51,7 @@ export function GraphicPlaceholder(props: GraphicPlaceholderProps) {
         className={className}
         unoptimized
         onError={() => setError(true)}
-        style={{ objectFit: 'cover' }}
+        style={{ objectFit }}
       />
     )
   }
@@ -64,7 +66,7 @@ export function GraphicPlaceholder(props: GraphicPlaceholderProps) {
       className={className}
       unoptimized
       onError={() => setError(true)}
-      style={{ objectFit: 'cover' }}
+      style={{ objectFit }}
     />
   )
 }

--- a/neufin-web/components/landing/HomeLandingPage.tsx
+++ b/neufin-web/components/landing/HomeLandingPage.tsx
@@ -8,6 +8,7 @@ import { Check } from 'lucide-react'
 import type { MarketRegime, ResearchNote } from '@/lib/api'
 import { GraphicPlaceholder } from '@/components/GraphicPlaceholder'
 import SwarmHeroTerminal from '@/components/landing/SwarmHeroTerminal'
+import LandingSwarmChatDock from '@/components/landing/LandingSwarmChatDock'
 
 const SWARM_AGENTS = [
   {
@@ -240,15 +241,19 @@ export default function HomeLandingPage({
         {/* Hero */}
         <section className="relative flex min-h-screen items-center overflow-hidden bg-white pt-16">
           <div
-            className="pointer-events-none absolute right-1/4 top-1/4 h-[600px] w-[600px] rounded-full bg-[#1EB8CC]/5 blur-3xl"
+            className="landing-animated-grid pointer-events-none absolute inset-0 z-0 opacity-[0.32]"
             aria-hidden
           />
           <div
-            className="pointer-events-none absolute bottom-1/4 left-1/4 h-[400px] w-[400px] rounded-full bg-[#8B5CF6]/4 blur-3xl"
+            className="pointer-events-none absolute right-1/4 top-1/4 z-0 h-[600px] w-[600px] rounded-full bg-[#1EB8CC]/5 blur-3xl"
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute bottom-1/4 left-1/4 z-0 h-[400px] w-[400px] rounded-full bg-[#8B5CF6]/4 blur-3xl"
             aria-hidden
           />
 
-          <div className="relative mx-auto max-w-7xl px-6 py-24">
+          <div className="relative z-10 mx-auto max-w-7xl px-6 py-24">
             <div className="grid grid-cols-1 items-center gap-16 lg:grid-cols-2">
               <div className="min-w-0 max-w-4xl">
               <motion.div
@@ -347,6 +352,10 @@ export default function HomeLandingPage({
                 {/* Swarm terminal — original hero right column (dark live demo) */}
                 <div className="relative w-full max-w-lg">
                   <div
+                    className="pointer-events-none absolute -left-24 top-1/2 z-0 h-56 w-56 -translate-y-1/2 rounded-full bg-[#1EB8CC]/12 blur-3xl"
+                    aria-hidden
+                  />
+                  <div
                     className="pointer-events-none absolute -inset-4 -z-10 scale-95 rounded-3xl bg-[#1EB8CC]/15 blur-3xl"
                     aria-hidden
                   />
@@ -393,8 +402,12 @@ export default function HomeLandingPage({
         </section>
 
         {/* Metrics */}
-        <section className="border-y border-[#E2E8F0] bg-[#F8FAFC] py-12">
-          <div className="mx-auto max-w-7xl px-6">
+        <section className="relative overflow-hidden border-y border-[#E2E8F0] bg-[#F8FAFC] py-12">
+          <div
+            className="landing-animated-grid pointer-events-none absolute inset-0 opacity-[0.22]"
+            aria-hidden
+          />
+          <div className="relative z-10 mx-auto max-w-7xl px-6">
             <div className="grid grid-cols-2 gap-8 lg:grid-cols-4">
               {(
                 [
@@ -425,16 +438,23 @@ export default function HomeLandingPage({
         {/* Seven agents */}
         <section className="relative bg-white py-24" id="demo">
           <div className="pointer-events-none absolute inset-0 overflow-hidden">
-            <GraphicPlaceholder
-              src="/graphics/ai-agents-visualization.png"
-              alt=""
-              width={500}
-              height={500}
-              className="absolute right-0 top-1/2 w-[500px] -translate-y-1/2 rounded-3xl opacity-10"
-              label="Agent visualization — Add ai-agents-visualization.png to public/graphics/"
-            />
+            <div className="absolute inset-0 flex items-center justify-center px-4 py-8">
+              <div className="relative h-[min(72vh,820px)] w-full max-w-6xl opacity-[0.15]">
+                <GraphicPlaceholder
+                  src="/graphics/ai-agents-visualization.png"
+                  alt=""
+                  fill
+                  sizes="(max-width: 1024px) 100vw, 72rem"
+                  objectFit="contain"
+                  className="object-contain"
+                  label="Agent visualization — Add ai-agents-visualization.png to public/graphics/"
+                />
+              </div>
+            </div>
           </div>
-          <div className="relative mx-auto max-w-7xl px-6">
+          <div className="pointer-events-none absolute left-[6%] top-[28%] z-0 h-44 w-44 rounded-full bg-[#1EB8CC]/10 blur-3xl" aria-hidden />
+          <div className="pointer-events-none absolute bottom-[18%] right-[8%] z-0 h-40 w-40 rounded-full bg-[#1EB8CC]/8 blur-3xl" aria-hidden />
+          <div className="relative z-10 mx-auto max-w-7xl px-6">
             <div className="mb-16 text-center">
               <motion.p
                 initial={{ opacity: 0, y: 10 }}
@@ -475,8 +495,12 @@ export default function HomeLandingPage({
                   viewport={{ once: true }}
                   transition={{ duration: 0.45, delay: i * 0.07 }}
                   whileHover={{ y: -4, transition: { duration: 0.2 } }}
-                  className="cursor-default rounded-2xl border border-[#E2E8F0] bg-white p-6 transition-shadow duration-300 hover:shadow-[0_8px_32px_rgba(0,0,0,0.08)]"
+                  className="relative cursor-default overflow-hidden rounded-2xl border border-[#E2E8F0] bg-white p-6 transition-shadow duration-300 hover:shadow-[0_8px_32px_rgba(0,0,0,0.08)]"
                 >
+                  <div
+                    className="pointer-events-none absolute -right-6 -top-8 h-28 w-28 rounded-full bg-[#1EB8CC]/7 blur-2xl"
+                    aria-hidden
+                  />
                   <div
                     className="mb-5 flex h-11 w-11 items-center justify-center rounded-xl text-sm font-black tracking-wide text-white"
                     style={{ background: a.color }}
@@ -501,8 +525,12 @@ export default function HomeLandingPage({
                   viewport={{ once: true }}
                   transition={{ duration: 0.45, delay: (i + 4) * 0.07 }}
                   whileHover={{ y: -4, transition: { duration: 0.2 } }}
-                  className="cursor-default rounded-2xl border border-[#E2E8F0] bg-white p-6 transition-shadow duration-300 hover:shadow-[0_8px_32px_rgba(0,0,0,0.08)]"
+                  className="relative cursor-default overflow-hidden rounded-2xl border border-[#E2E8F0] bg-white p-6 transition-shadow duration-300 hover:shadow-[0_8px_32px_rgba(0,0,0,0.08)]"
                 >
+                  <div
+                    className="pointer-events-none absolute -right-6 -top-8 h-28 w-28 rounded-full bg-[#1EB8CC]/7 blur-2xl"
+                    aria-hidden
+                  />
                   <div
                     className="mb-5 flex h-11 w-11 items-center justify-center rounded-xl text-sm font-black text-white"
                     style={{ background: a.color }}
@@ -533,41 +561,43 @@ export default function HomeLandingPage({
         </section>
 
         {/* Value proposition */}
-        <section className="bg-[#F8FAFC] py-24">
-          <div className="mx-auto max-w-7xl px-6">
-            <div className="grid grid-cols-1 items-center gap-20 lg:grid-cols-2">
+        <section className="relative overflow-hidden bg-[#F8FAFC] py-24">
+          <div className="pointer-events-none absolute -left-16 top-24 h-64 w-64 rounded-full bg-[#1EB8CC]/8 blur-3xl" aria-hidden />
+          <div className="pointer-events-none absolute bottom-16 right-0 h-52 w-52 rounded-full bg-[#1EB8CC]/6 blur-3xl" aria-hidden />
+          <div className="relative z-10 mx-auto max-w-7xl px-6">
+            <div className="grid grid-cols-1 items-center gap-16 lg:grid-cols-2 lg:gap-20">
               <motion.div
                 initial={{ opacity: 0, x: -24 }}
                 whileInView={{ opacity: 1, x: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.55 }}
+                className="relative"
               >
+                <div
+                  className="pointer-events-none absolute -right-4 top-1/2 h-48 w-48 -translate-y-1/2 rounded-full bg-[#1EB8CC]/8 blur-3xl"
+                  aria-hidden
+                />
                 <p className="mb-4 text-xs font-bold uppercase tracking-[0.15em] text-[#1EB8CC]">For Advisors</p>
                 <h2
                   className="mb-6 font-bold leading-tight tracking-tight text-[#0F172A]"
                   style={{ fontSize: 'clamp(24px, 2.8vw, 36px)' }}
                 >
-                  Stop spending 3 hours on a report your client reads in 3 minutes.
+                  IC-grade client intelligence without the manual report grind.
                 </h2>
-                <div className="space-y-3">
+                <div className="space-y-4">
                   {(
                     [
-                      [
-                        '3 hours building a quarterly report manually',
-                        'IC-grade brief in 60 seconds, white-labeled with your branding',
-                      ],
-                      [
-                        'No explanation when clients ask why they underperformed',
-                        'Behavioral bias detection with quantified dollar impact per position',
-                      ],
-                      [
-                        'Robo-advisors at 0.25% AUM undercutting your fee',
-                        'Demonstrate IC-level analysis that justifies your 1% advisory fee',
-                      ],
+                      'IC-grade brief in 60 seconds, white-labeled with your branding',
+                      'Behavioral bias detection with quantified dollar impact per position',
+                      'Demonstrate IC-level analysis that justifies your advisory fee',
                     ] as const
-                  ).map(([prob, sol], i) => (
-                    <div key={i} className="flex gap-4 rounded-xl border border-[#E2E8F0] bg-white p-5">
-                      <div className="mt-0.5 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-[#22C55E]">
+                  ).map((line, i) => (
+                    <div key={i} className="relative flex gap-4 overflow-hidden rounded-xl border border-[#E2E8F0] bg-white p-5">
+                      <div
+                        className="pointer-events-none absolute -right-8 -top-10 h-24 w-24 rounded-full bg-[#1EB8CC]/7 blur-2xl"
+                        aria-hidden
+                      />
+                      <div className="relative mt-0.5 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-[#22C55E]">
                         <svg className="h-3.5 w-3.5 text-white" fill="currentColor" viewBox="0 0 20 20" aria-hidden>
                           <path
                             fillRule="evenodd"
@@ -576,10 +606,7 @@ export default function HomeLandingPage({
                           />
                         </svg>
                       </div>
-                      <div>
-                        <p className="mb-1 text-sm text-[#94A3B8] line-through">{prob}</p>
-                        <p className="text-[14px] font-medium text-[#0F172A]">{sol}</p>
-                      </div>
+                      <p className="relative text-[15px] font-medium leading-relaxed text-[#0F172A]">{line}</p>
                     </div>
                   ))}
                 </div>
@@ -590,33 +617,33 @@ export default function HomeLandingPage({
                 whileInView={{ opacity: 1, x: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.55, delay: 0.1 }}
+                className="relative"
               >
+                <div
+                  className="pointer-events-none absolute -left-8 top-1/3 h-44 w-44 -translate-y-1/2 rounded-full bg-[#8B5CF6]/10 blur-3xl"
+                  aria-hidden
+                />
                 <p className="mb-4 text-xs font-bold uppercase tracking-[0.15em] text-[#8B5CF6]">For Platforms</p>
                 <h2
                   className="mb-6 font-bold leading-tight tracking-tight text-[#0F172A]"
                   style={{ fontSize: 'clamp(24px, 2.8vw, 36px)' }}
                 >
-                  One weekend integration, not six months of engineering.
+                  Behavioral intelligence through your stack — without a six-month build.
                 </h2>
-                <div className="space-y-3">
+                <div className="space-y-4">
                   {(
                     [
-                      [
-                        '6–12 months to build behavioral intelligence in-house',
-                        'REST API integration in a single weekend — 3 endpoints',
-                      ],
-                      [
-                        '$200K+ in development before your first client',
-                        'DNA score and 47 bias flags per portfolio, out of the box',
-                      ],
-                      [
-                        'Client churn spikes 15–25% in every market correction',
-                        'Churn risk detected before clients panic-sell — automated',
-                      ],
+                      'REST API integration in a single weekend — 3 endpoints',
+                      'DNA score and 47 bias flags per portfolio, out of the box',
+                      'Churn risk detected before clients panic-sell — automated',
                     ] as const
-                  ).map(([prob, sol], i) => (
-                    <div key={i} className="flex gap-4 rounded-xl border border-[#E2E8F0] bg-white p-5">
-                      <div className="mt-0.5 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-[#8B5CF6]">
+                  ).map((line, i) => (
+                    <div key={i} className="relative flex gap-4 overflow-hidden rounded-xl border border-[#E2E8F0] bg-white p-5">
+                      <div
+                        className="pointer-events-none absolute -right-8 -top-10 h-24 w-24 rounded-full bg-[#1EB8CC]/7 blur-2xl"
+                        aria-hidden
+                      />
+                      <div className="relative mt-0.5 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-[#8B5CF6]">
                         <svg className="h-3.5 w-3.5 text-white" fill="currentColor" viewBox="0 0 20 20" aria-hidden>
                           <path
                             fillRule="evenodd"
@@ -625,10 +652,7 @@ export default function HomeLandingPage({
                           />
                         </svg>
                       </div>
-                      <div>
-                        <p className="mb-1 text-sm text-[#94A3B8] line-through">{prob}</p>
-                        <p className="text-[14px] font-medium text-[#0F172A]">{sol}</p>
-                      </div>
+                      <p className="relative text-[15px] font-medium leading-relaxed text-[#0F172A]">{line}</p>
                     </div>
                   ))}
                 </div>
@@ -899,6 +923,8 @@ export default function HomeLandingPage({
           </div>
         </div>
       </footer>
+
+      <LandingSwarmChatDock />
     </div>
   )
 }

--- a/neufin-web/components/landing/LandingSwarmChatDock.tsx
+++ b/neufin-web/components/landing/LandingSwarmChatDock.tsx
@@ -1,0 +1,252 @@
+'use client'
+
+/**
+ * Landing-only floating swarm demo — POST /api/swarm/global-chat (same as GlobalChatWidget).
+ * Light glass shell; simulates agent handoffs while the backend responds.
+ */
+
+import React, { useCallback, useEffect, useRef, useState, KeyboardEvent } from 'react'
+import { MessageCircle, X, Send } from 'lucide-react'
+
+const STARTERS = [
+  'What does the 7-agent swarm do?',
+  'How is NeuFin different from a robo-advisor?',
+  'What does the IC report include?',
+  'How does the API integration work?',
+  'What is a DNA score?',
+  'How do I upload a portfolio?',
+] as const
+
+const HANDOFF_STEPS = [
+  'Triage Agent: routing your question…',
+  'Strategist Agent is analyzing…',
+  'Quant Analyst is refining the response…',
+] as const
+
+interface Message {
+  role: 'user' | 'assistant'
+  text: string
+  keyNumbers?: Record<string, string>
+  action?: string
+  agent?: string
+  loading?: boolean
+}
+
+export default function LandingSwarmChatDock() {
+  const [open, setOpen] = useState(false)
+  const [messages, setMessages] = useState<Message[]>([])
+  const [input, setInput] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [handoffIdx, setHandoffIdx] = useState(0)
+  const bottomRef = useRef<HTMLDivElement>(null)
+  const handoffTimer = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const clearHandoffTimer = useCallback(() => {
+    if (handoffTimer.current) {
+      clearInterval(handoffTimer.current)
+      handoffTimer.current = null
+    }
+  }, [])
+
+  useEffect(() => {
+    if (open && messages.length === 0) {
+      setMessages([
+        {
+          role: 'assistant',
+          text:
+            'Hi — I\'m the Triage Agent for this product demo. Ask anything about NeuFin\'s swarm, DNA scores, uploads, IC reports, or API integration. I\'ll coordinate specialist agents behind the scenes.',
+          agent: 'triage',
+        },
+      ])
+    }
+  }, [open, messages.length])
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages, handoffIdx])
+
+  useEffect(() => () => clearHandoffTimer(), [clearHandoffTimer])
+
+  const send = async (question: string) => {
+    if (!question.trim() || loading) return
+    const q = question.trim()
+    setInput('')
+    setMessages((prev) => [...prev, { role: 'user', text: q }])
+    setLoading(true)
+    setHandoffIdx(0)
+    setMessages((prev) => [...prev, { role: 'assistant', text: '', agent: 'swarm', loading: true }])
+
+    handoffTimer.current = setInterval(() => {
+      setHandoffIdx((i) => (i + 1 >= HANDOFF_STEPS.length ? HANDOFF_STEPS.length - 1 : i + 1))
+    }, 700)
+
+    try {
+      const res = await fetch('/api/swarm/global-chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: q, agent_type: 'general' }),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const data = await res.json()
+      const reply = data.reply ?? data.response?.answer ?? 'Here is what I can share about NeuFin.'
+      const keyNumbers = data.key_numbers ?? data.response?.key_numbers ?? {}
+      const action = data.action ?? data.response?.recommended_action ?? ''
+      clearHandoffTimer()
+      setMessages((prev) => [
+        ...prev.slice(0, -1),
+        {
+          role: 'assistant',
+          agent: data.agent ?? 'general',
+          text: reply,
+          keyNumbers,
+          action,
+        },
+      ])
+    } catch (e: unknown) {
+      clearHandoffTimer()
+      const msg = e instanceof Error ? e.message : 'Unknown error'
+      setMessages((prev) => [
+        ...prev.slice(0, -1),
+        {
+          role: 'assistant',
+          agent: 'general',
+          text: `We could not reach the swarm right now. Please try again. (${msg})`,
+        },
+      ])
+    } finally {
+      clearHandoffTimer()
+      setLoading(false)
+      setHandoffIdx(0)
+    }
+  }
+
+  const handleKey = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      void send(input)
+    }
+  }
+
+  const showStarters = messages.length === 1 && !loading
+
+  return (
+    <div className="fixed bottom-24 right-4 z-[9980] flex w-[min(100vw-2rem,380px)] flex-col-reverse items-end gap-3 sm:bottom-6 sm:right-6">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-label={open ? 'Close swarm demo chat' : 'Open swarm product demo chat'}
+        className="flex h-[52px] w-[52px] items-center justify-center rounded-full border border-[#1EB8CC]/35 bg-[#0F172A] text-white shadow-[0_6px_28px_rgba(30,184,204,0.35)] transition-transform hover:scale-[1.03] active:scale-[0.98]"
+      >
+        {open ? <X className="h-5 w-5" strokeWidth={2} /> : <MessageCircle className="h-5 w-5" strokeWidth={2} />}
+      </button>
+
+      {open && (
+        <div
+          className="glass-card-light flex h-[min(72vh,520px)] w-full flex-col overflow-hidden rounded-2xl border border-[#1EB8CC]/25 shadow-[0_20px_50px_rgba(15,23,42,0.12)] animate-[landingChatIn_0.2s_ease-out]"
+          role="dialog"
+          aria-label="NeuFin swarm product demo"
+        >
+            <div className="flex items-center justify-between border-b border-[#E2E8F0]/90 bg-white/60 px-4 py-3">
+              <div>
+                <p className="text-sm font-semibold text-[#0F172A]">Swarm product demo</p>
+                <p className="text-xs font-medium uppercase tracking-wide text-[#1EB8CC]">Triage → specialist agents</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="rounded-lg p-1.5 text-[#94A3B8] transition-colors hover:bg-[#F1F5F9] hover:text-[#0F172A]"
+                aria-label="Close demo chat"
+              >
+                <X className="h-4 w-4" strokeWidth={2} />
+              </button>
+            </div>
+
+            <p className="border-b border-[#F1F5F9] bg-[#F8FAFC]/80 px-4 py-2 text-[11px] leading-snug text-[#64748B]">
+              Intelligent assistant preview — answers reflect live swarm routing where available.
+            </p>
+
+            <div className="flex flex-1 flex-col gap-3 overflow-y-auto bg-gradient-to-b from-white to-[#F8FAFC]/95 px-4 py-3">
+              {showStarters && (
+                <div className="mb-1 flex flex-wrap gap-1.5">
+                  {STARTERS.map((s) => (
+                    <button
+                      key={s}
+                      type="button"
+                      onClick={() => void send(s)}
+                      className="rounded-full border border-[#E2E8F0] bg-white px-2.5 py-1 text-left text-xs font-medium leading-snug text-[#475569] transition-colors hover:border-[#1EB8CC]/40 hover:text-[#0F172A]"
+                    >
+                      {s}
+                    </button>
+                  ))}
+                </div>
+              )}
+
+              {messages.map((msg, idx) => (
+                <div key={idx} className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+                  <div className="max-w-[88%] flex flex-col gap-1">
+                    {msg.loading ? (
+                      <div className="rounded-2xl rounded-bl-md border border-[#E2E8F0] bg-white px-3 py-2.5 shadow-sm">
+                        <p className="text-xs font-semibold text-[#1EB8CC]">{HANDOFF_STEPS[handoffIdx]}</p>
+                        <p className="mt-1 text-xs text-[#64748B]">Coordinating the agent swarm…</p>
+                      </div>
+                    ) : msg.role === 'user' ? (
+                      <div className="rounded-2xl rounded-br-md border border-[#1EB8CC]/25 bg-[#E0F7FA]/90 px-3 py-2 text-sm leading-relaxed text-[#0F172A]">
+                        {msg.text}
+                      </div>
+                    ) : (
+                      <>
+                        <div className="rounded-2xl rounded-bl-md border border-[#E2E8F0] bg-white px-3 py-2 text-sm leading-relaxed text-[#334155] shadow-sm">
+                          {msg.text}
+                        </div>
+                        {msg.keyNumbers && Object.keys(msg.keyNumbers).length > 0 && (
+                          <div className="flex flex-wrap gap-x-3 gap-y-1 rounded-lg border border-[#E2E8F0] bg-[#F8FAFC] px-2.5 py-2">
+                            {Object.entries(msg.keyNumbers).map(([k, v]) => (
+                              <div key={k} className="flex items-center gap-1 text-xs">
+                                <span className="font-medium uppercase tracking-wider text-[#94A3B8]">{k}</span>
+                                <span className="font-semibold text-[#0F172A]">{String(v)}</span>
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                        {msg.action ? (
+                          <p className="border-l-2 border-[#1EB8CC]/50 pl-2 text-xs font-medium text-[#0F172A]">{msg.action}</p>
+                        ) : null}
+                      </>
+                    )}
+                  </div>
+                </div>
+              ))}
+              <div ref={bottomRef} />
+            </div>
+
+            <div className="flex items-center gap-2 border-t border-[#E2E8F0] bg-white/90 px-3 py-3">
+              <input
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={handleKey}
+                disabled={loading}
+                placeholder="Ask about NeuFin, DNA score, API…"
+                className="min-w-0 flex-1 rounded-lg border border-[#E2E8F0] bg-white px-3 py-2 text-sm text-[#0F172A] outline-none ring-[#1EB8CC]/0 transition-[box-shadow,border-color] placeholder:text-[#94A3B8] focus:border-[#1EB8CC]/40 focus:ring-2 focus:ring-[#1EB8CC]/15 disabled:opacity-50"
+              />
+              <button
+                type="button"
+                onClick={() => void send(input)}
+                disabled={loading || !input.trim()}
+                className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-[#1EB8CC]/30 bg-[#1EB8CC] text-white transition-opacity disabled:cursor-not-allowed disabled:border-[#E2E8F0] disabled:bg-[#F1F5F9] disabled:text-[#CBD5E1]"
+                aria-label="Send message"
+              >
+                <Send className="h-4 w-4" strokeWidth={2} />
+              </button>
+            </div>
+          </div>
+      )}
+
+      <style>{`
+        @keyframes landingChatIn {
+          from { opacity: 0; transform: translateY(12px) scale(0.98); }
+          to { opacity: 1; transform: translateY(0) scale(1); }
+        }
+      `}</style>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
Landing-only UI: removes crossed-out comparison copy, fixes the seven-agent section background graphic, adds subtle institutional motion/texture, restores a floating swarm product-demo chat, and adds a light motion treatment to the dashboard empty-state IC preview.

## Changes
- **HomeLandingPage**: For Advisors / For Platforms now use positive headlines and single-line capability cards (no `line-through`). Seven-agent section uses `ai-agents-visualization.png` centered behind cards at 15% opacity, `object-fit: contain`, `pointer-events: none`. Hero + metrics get low-contrast animated grid; teal glow orbs on agent and value cards; `LandingSwarmChatDock` mounted after footer.
- **LandingSwarmChatDock** (new): Fixed bottom-right (higher on small screens to reduce overlap with thumb/footer), `glass-card-light` shell, Triage welcome + NeuFin starter prompts, cycling handoff copy while `POST /api/swarm/global-chat` runs.
- **globals.css**: `.glass-card-light` → 12px blur + teal border; `.landing-animated-grid` + reduced-motion guard.
- **GraphicPlaceholder**: optional `objectFit` (`cover` | `contain`) for watermark-style images.
- **dashboard/page.tsx**: Slide-in animation for IC report placeholder on empty-state panel (framer-motion).

## Validation
- `npm run build` (neufin-web) passes.

## Screenshots
Not attached in this environment; verify hero grid, swarm background, value cards, and chat dock in browser.

Made with [Cursor](https://cursor.com)