### PR TITLE
feat: Financial Model Studio + Quant Dashboard + IC Report Modes + Dashboard Modes

### DIFF
--- a/neufin-backend/services/pdf_generator.py
+++ b/neufin-backend/services/pdf_generator.py
@@ -8,7 +8,7 @@ Bank-grade IC PDF, 11 pages, two themes.
 Orchestration
 ─────────────
   generate_advisor_report()  async orchestrator (logo fetch, swarm norm)
-      └── _build_pdf_sync()  sync builder (11 page functions, no I/O)
+      └── _build_pdf_sync()  sync builder (12 page functions, no I/O)
 
 All page-builder functions are pure:
   _page_N(ctx, extra, pal, st, cw) -> list[Flowable]
@@ -3255,6 +3255,243 @@ def _page_alpha_opportunities(
     return items
 
 
+# ─── PAGE 8b — QUANT MODEL OUTPUTS (standalone) ─────────────────────────────
+
+
+def _page_quant_model_outputs(
+    ctx: dict, extra: dict, pal: dict, st: dict, cw: float
+) -> list:
+    """Dedicated IC-grade page for quantitative model outputs and analytics."""
+    items: list = []
+    labels = ctx.get("section_labels") or {}
+    items.extend(
+        _ic_body_section_header(
+            "6",
+            str(labels.get("quant_model_outputs") or "QUANT MODEL OUTPUTS"),
+            "Factor decomposition · risk metrics · scenario implications",
+            pal,
+            st,
+            cw,
+        )
+    )
+
+    q_modes = ctx.get("quant_modes_selected") or []
+    q_contrib = ctx.get("quant_model_contribution_summary") or {}
+    q_tradeoffs = ctx.get("quant_alpha_risk_tradeoffs") or {}
+    q_scen = ctx.get("quant_scenario_implications") or {}
+
+    # ── Selected modes banner ─────────────────────────────────────────────────
+    modes_text = (
+        ", ".join(str(m).upper() for m in q_modes)
+        if q_modes
+        else "Default (no overlay modes selected)"
+    )
+    items.append(
+        Table(
+            [
+                [
+                    Paragraph(
+                        f"<b>Active Quant Modes:</b> {_xml(modes_text)}",
+                        ParagraphStyle(
+                            "qm_modes_" + pal["theme"],
+                            fontName="Helvetica",
+                            fontSize=9,
+                            textColor=pal["text_pri"],
+                            leading=13,
+                        ),
+                    )
+                ]
+            ],
+            colWidths=[cw],
+            style=TableStyle(
+                [
+                    ("BACKGROUND", (0, 0), (-1, -1), pal["card"]),
+                    ("BOX", (0, 0), (-1, -1), 1, ACCENT_TEAL),
+                    ("LEFTPADDING", (0, 0), (-1, -1), 10),
+                    ("TOPPADDING", (0, 0), (-1, -1), 8),
+                    ("BOTTOMPADDING", (0, 0), (-1, -1), 8),
+                ]
+            ),
+        )
+    )
+    items.append(Spacer(1, 10))
+
+    # ── Factor / model contribution chart (via matplotlib bar chart) ──────────
+    if HAS_MPL and q_contrib:
+        try:
+            labels_fc = list(q_contrib.keys())[:8]
+            vals_fc = []
+            for k in labels_fc:
+                try:
+                    vals_fc.append(round(float(q_contrib[k]) * 100, 2))
+                except (TypeError, ValueError):
+                    vals_fc.append(0.0)
+
+            if labels_fc and any(v != 0 for v in vals_fc):
+                fig, ax = plt.subplots(figsize=(6.5, 2.4))
+                bg = pal["bg_hex"]
+                fig.patch.set_facecolor(bg)
+                ax.set_facecolor(bg)
+                bar_colors = [
+                    "#1EB8CC",
+                    "#0EA5E9",
+                    "#6366F1",
+                    "#8B5CF6",
+                    "#10B981",
+                    "#F59E0B",
+                    "#EF4444",
+                    "#EC4899",
+                ]
+                ax.barh(
+                    labels_fc,
+                    vals_fc,
+                    color=bar_colors[: len(labels_fc)],
+                    height=0.6,
+                )
+                ax.set_xlabel("Contribution %", fontsize=8, color=pal["mut_hex"])
+                ax.tick_params(labelsize=8, colors=pal["text_hex"])
+                for spine in ax.spines.values():
+                    spine.set_edgecolor(_hex(pal["border"]))
+                ax.set_facecolor(bg)
+                fig.patch.set_facecolor(bg)
+                buf = io.BytesIO()
+                fig.savefig(
+                    buf,
+                    format="png",
+                    dpi=140,
+                    bbox_inches="tight",
+                    facecolor=bg,
+                )
+                plt.close(fig)
+                buf.seek(0)
+                chart_img = Image(buf, width=cw, height=110)
+                items.append(Paragraph("FACTOR CONTRIBUTION BREAKDOWN", st["h3"]))
+                items.append(chart_img)
+                items.append(Spacer(1, 10))
+        except Exception as e:
+            logger.warning("pdf.quant_contrib_chart_failed", error=str(e))
+
+    # ── Model contribution table (text fallback / always shown) ──────────────
+    if q_contrib:
+        items.append(Paragraph("MODEL CONTRIBUTION SUMMARY", st["h3"]))
+        contrib_rows = [["Factor / Model Layer", "Contribution Weight"]]
+        for k, v in q_contrib.items():
+            try:
+                pct = f"{round(float(v) * 100, 1)}%"
+            except (TypeError, ValueError):
+                pct = str(v)
+            contrib_rows.append([_xml(str(k)), pct])
+        items.append(
+            Table(contrib_rows, colWidths=[cw * 0.65, cw * 0.35], style=_tbl_std(pal))
+        )
+        items.append(Spacer(1, 10))
+    else:
+        items.append(
+            _amber_banner_table(
+                "Model contribution summary unavailable. "
+                "Run quant analysis with at least one mode to populate factor weights.",
+                pal,
+                st,
+                cw,
+            )
+        )
+        items.append(Spacer(1, 10))
+
+    # ── Alpha vs risk tradeoffs ───────────────────────────────────────────────
+    items.append(Paragraph("ALPHA vs RISK TRADEOFFS", st["h3"]))
+    alpha_val = q_tradeoffs.get("sharpe_proxy")
+    vol_val = q_tradeoffs.get("volatility_annualized_proxy")
+    dd_val = q_tradeoffs.get("max_drawdown_proxy")
+
+    def _fmt_proxy(v: Any, pct: bool = False) -> str:
+        if v is None:
+            return "n/a"
+        try:
+            f = float(v)
+            return f"{f * 100:.1f}%" if pct else f"{f:.3f}"
+        except (TypeError, ValueError):
+            return str(v)
+
+    tradeoff_rows = [
+        ["Metric", "Proxy Value", "Interpretation"],
+        [
+            "Sharpe Proxy",
+            _fmt_proxy(alpha_val),
+            "≥ 1.0 = strong risk-adjusted return",
+        ],
+        [
+            "Annualised Volatility",
+            _fmt_proxy(vol_val, pct=True),
+            "< 15% = institutional target",
+        ],
+        [
+            "Max Drawdown Proxy",
+            _fmt_proxy(dd_val, pct=True),
+            "< 20% = acceptable downside",
+        ],
+    ]
+    items.append(
+        Table(tradeoff_rows, colWidths=[130, 100, cw - 230], style=_tbl_std(pal))
+    )
+    items.append(Spacer(1, 10))
+
+    # ── Scenario implications ─────────────────────────────────────────────────
+    items.append(Paragraph("SCENARIO IMPLICATIONS", st["h3"]))
+    forecast = (
+        q_scen.get("forecast") if isinstance(q_scen.get("forecast"), dict) else {}
+    ) or {}
+    stress = (
+        q_scen.get("stress") if isinstance(q_scen.get("stress"), dict) else {}
+    ) or {}
+    regime_ctx = (
+        q_scen.get("regime_context")
+        if isinstance(q_scen.get("regime_context"), dict)
+        else {}
+    ) or {}
+
+    scen_rows = [
+        ["Dimension", "Value", "Notes"],
+        [
+            "Forecast Horizon",
+            f"{forecast.get('horizon_days', 'n/a')} days",
+            "Quant model look-ahead window",
+        ],
+        [
+            "Volatility Shift",
+            f"{forecast.get('volatility_shift_pct_vs_baseline', 'n/a')}%",
+            "vs baseline assumption",
+        ],
+        [
+            "Stress Scenarios",
+            str(stress.get("scenarios_sampled", "n/a")),
+            "Monte Carlo paths sampled",
+        ],
+        [
+            "Regime Context",
+            _xml(str(regime_ctx.get("label", "n/a"))[:50]),
+            f"Conf: {regime_ctx.get('confidence', 'n/a')}",
+        ],
+    ]
+    items.append(
+        Table(scen_rows, colWidths=[130, 120, cw - 250], style=_tbl_std(pal))
+    )
+
+    if not q_contrib and not q_tradeoffs and not any(
+        [forecast, stress, regime_ctx]
+    ):
+        items.append(Spacer(1, 8))
+        items.append(
+            Paragraph(
+                "Full quant model output requires the Swarm IC analysis to be run "
+                "with at least one quantitative mode selected (institutional, trading, "
+                "alpha, macro, allocation, forecast, or risk).",
+                st["muted"],
+            )
+        )
+
+    return items
+
+
 # ─── PAGE 10 — 90-DAY DIRECTIVES ──────────────────────────────────────────────
 
 
@@ -3693,12 +3930,14 @@ def _build_pdf_sync(
         elems.append(PageBreak())
 
     # Order: §2 executive → §3 snapshot → §4 risk (macro, correlation) →
-    # §5 behavioral → §6 scenarios → §7 recommendations (tax, alpha, directives) → §8 appendix
+    # §5 behavioral → §6 quant model outputs → §7 scenarios →
+    # §8 recommendations (tax, alpha, directives) → §9 appendix
     _add_page(_page_executive_memo, ctx, extra, pal, st, cw)
     _add_page(_page_portfolio_snapshot, ctx, extra, pal, st, cw)
     _add_page(_page_macro_regime, ctx, extra, pal, st, cw)
     _add_page(_page_risk_correlation, ctx, extra, pal, st, cw)
     _add_page(_page_behavioral_dna, ctx, extra, pal, st, cw)
+    _add_page(_page_quant_model_outputs, ctx, extra, pal, st, cw)
     _add_page(_page_stress_testing, ctx, extra, pal, st, cw)
     _add_page(_page_tax_optimization, ctx, extra, pal, st, cw)
     _add_page(_page_alpha_opportunities, ctx, extra, pal, st, cw)

--- a/neufin-backend/services/pdf_generator.py
+++ b/neufin-backend/services/pdf_generator.py
@@ -3472,13 +3472,9 @@ def _page_quant_model_outputs(
             f"Conf: {regime_ctx.get('confidence', 'n/a')}",
         ],
     ]
-    items.append(
-        Table(scen_rows, colWidths=[130, 120, cw - 250], style=_tbl_std(pal))
-    )
+    items.append(Table(scen_rows, colWidths=[130, 120, cw - 250], style=_tbl_std(pal)))
 
-    if not q_contrib and not q_tradeoffs and not any(
-        [forecast, stress, regime_ctx]
-    ):
+    if not q_contrib and not q_tradeoffs and not any([forecast, stress, regime_ctx]):
         items.append(Spacer(1, 8))
         items.append(
             Paragraph(

--- a/neufin-web/app/dashboard/page.tsx
+++ b/neufin-web/app/dashboard/page.tsx
@@ -107,54 +107,81 @@ export default function DashboardPage() {
             label: "Strategic Risk Budget",
             value:
               latestDna?.weighted_beta != null
-                ? `${latestDna.weighted_beta.toFixed(2)} beta`
+                ? `${latestDna.weighted_beta.toFixed(2)} β vs SPY 1.00`
                 : "Awaiting beta",
             tone: "text-[#0F172A]",
+            sub: "Weighted portfolio beta",
           },
           {
             label: "Regime Priority",
             value: formatRegimeLabel(regime),
             tone: "text-[#0B5561]",
+            sub:
+              (regime as { confidence?: number } | null)?.confidence != null
+                ? `${Math.round(((regime as { confidence?: number }).confidence ?? 0) * 100)}% confidence`
+                : "Portfolio-derived classification",
           },
           {
             label: "Capital at Review",
             value: positionsCount != null ? `${positionsCount} positions` : "—",
             tone: "text-[#0F172A]",
+            sub:
+              latestPortfolio?.total_value != null
+                ? `$${Number(latestPortfolio.total_value).toLocaleString()} AUM`
+                : "Upload portfolio for AUM",
           },
         ]
       : dashboardMode === "trader"
         ? [
             {
-              label: "Execution Focus",
-              value: "Intraday volatility and correlation shocks",
-              tone: "text-[#7C2D12]",
-            },
-            {
               label: "Signal Priority",
-              value: swarmReport?.headline || "Awaiting quant signal",
+              value: swarmReport?.headline ?? "Awaiting quant signal",
               tone: "text-[#0F172A]",
+              sub: "Latest Swarm IC headline",
             },
             {
-              label: "Quick Action",
-              value: "Open Quant Dashboard for live paths",
+              label: "Execution Focus",
+              value:
+                latestDna?.weighted_beta != null
+                  ? `Beta ${latestDna.weighted_beta.toFixed(2)} — intraday risk`
+                  : "Run analysis for beta",
+              tone: "text-[#7C2D12]",
+              sub: "Monitor correlation shocks",
+            },
+            {
+              label: "Quant Console",
+              value: "Open Quant Dashboard →",
               tone: "text-[#0B5561]",
+              sub: "Live paths, factor decomp, VaR",
             },
           ]
         : [
             {
               label: "Client Narrative",
-              value: latestDna?.recommendation || "Portfolio recommendation pending",
+              value:
+                latestDna?.recommendation ??
+                "Portfolio recommendation pending",
               tone: "text-[#0F172A]",
+              sub: "From Behavioral DNA analysis",
             },
             {
-              label: "Advisor Priority",
-              value: "Tax positioning and regime communication",
+              label: "Harvest Opportunity",
+              value:
+                (latestDna as { tax_analysis?: { total_harvest_opp?: number } } | null)
+                  ?.tax_analysis?.total_harvest_opp != null
+                  ? `$${Number(
+                      (latestDna as { tax_analysis?: { total_harvest_opp?: number } })
+                        .tax_analysis!.total_harvest_opp!,
+                    ).toLocaleString()} harvestable`
+                  : "Upload cost basis",
               tone: "text-[#0B5561]",
+              sub: "Tax-loss harvesting estimate",
             },
             {
               label: "Memo Readiness",
               value: swarmReport ? "Swarm insights available" : "Run swarm for memo",
-              tone: "text-[#7C2D12]",
+              tone: swarmReport ? "text-emerald-700" : "text-[#7C2D12]",
+              sub: "IC report generation ready",
             },
           ];
 
@@ -185,6 +212,9 @@ export default function DashboardPage() {
                 {w.label}
               </p>
               <p className={`mt-1 text-sm font-semibold ${w.tone}`}>{w.value}</p>
+              {w.sub && (
+                <p className="mt-0.5 text-xs text-[#94A3B8]">{w.sub}</p>
+              )}
             </div>
           ))}
         </section>

--- a/neufin-web/app/dashboard/quant/page.tsx
+++ b/neufin-web/app/dashboard/quant/page.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import {
+  Area,
+  AreaChart,
   Bar,
   BarChart,
   CartesianGrid,
@@ -84,6 +86,52 @@ const MODES_BY_DASHBOARD: Record<DashboardMode, string[]> = {
   advisor: ["institutional", "alpha", "risk", "macro"],
 };
 
+const FACTOR_COLORS = [
+  "#1EB8CC", "#0EA5E9", "#6366F1", "#8B5CF6",
+  "#10B981", "#F59E0B", "#EF4444", "#EC4899",
+];
+
+function metricColor(label: string, value: string): string {
+  const num = parseFloat(value);
+  if (isNaN(num)) return "#0F172A";
+  if (label === "Sharpe Proxy") {
+    if (num >= 1.0) return "#16A34A";
+    if (num >= 0.5) return "#D97706";
+    return "#DC2626";
+  }
+  if (label === "Alpha Score") {
+    if (num >= 70) return "#16A34A";
+    if (num >= 40) return "#D97706";
+    return "#DC2626";
+  }
+  if (label === "Volatility") {
+    const raw = num; // already in %
+    if (raw <= 10) return "#16A34A";
+    if (raw <= 20) return "#D97706";
+    return "#DC2626";
+  }
+  if (label === "Max Drawdown") {
+    if (num >= -10) return "#16A34A";
+    if (num >= -20) return "#D97706";
+    return "#DC2626";
+  }
+  return "#0F172A";
+}
+
+function alphaConfidenceColors(conf: number): { text: string; bar: string; border: string } {
+  const pct = conf <= 1 ? conf * 100 : conf;
+  if (pct >= 75) return { text: "#16A34A", bar: "#22C55E", border: "#BBF7D0" };
+  if (pct >= 60) return { text: "#D97706", bar: "#F59E0B", border: "#FDE68A" };
+  return { text: "#64748B", bar: "#94A3B8", border: "#E2E8F0" };
+}
+
+function edgeStroke(corr: number): string {
+  const abs = Math.abs(corr);
+  if (abs > 0.7) return "#EF4444";
+  if (abs > 0.4) return "#F59E0B";
+  return "#94A3B8";
+}
+
 export default function QuantDashboardPage() {
   const {
     advancedQuantMode,
@@ -96,6 +144,10 @@ export default function QuantDashboardPage() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [activeNode, setActiveNode] = useState<string | null>(null);
+  const [activeEdge, setActiveEdge] = useState<{
+    source: string; target: string; correlation: number;
+  } | null>(null);
+  const [confLevel, setConfLevel] = useState<0.9 | 0.95 | 0.99>(0.95);
 
   const selectedModes = useMemo(
     () => MODES_BY_DASHBOARD[dashboardMode],
@@ -117,21 +169,40 @@ export default function QuantDashboardPage() {
       .finally(() => setLoading(false));
   }, [advancedQuantMode, selectedModes]);
 
-  const monteCarloRows = useMemo(() => {
+  // Compute p5 / p50 / p95 percentile bands from all Monte Carlo paths
+  const monteCarloPercentiles = useMemo(() => {
     const paths = data?.charts.monte_carlo_paths ?? [];
-    const map = new Map<number, Record<string, number>>();
+    if (paths.length === 0) return [];
+    const dayMap = new Map<number, number[]>();
     for (const path of paths) {
-      for (const p of path.points) {
-        if (!map.has(p.day)) map.set(p.day, { day: p.day });
-        map.get(p.day)![path.path_id] = p.value;
+      for (const pt of path.points) {
+        if (!dayMap.has(pt.day)) dayMap.set(pt.day, []);
+        dayMap.get(pt.day)!.push(pt.value);
       }
     }
-    return [...map.values()].sort((a, b) => (a.day as number) - (b.day as number));
+    return [...dayMap.entries()]
+      .sort((a, b) => a[0] - b[0])
+      .map(([day, vals]) => {
+        const sorted = [...vals].sort((a, b) => a - b);
+        const n = sorted.length;
+        return {
+          day,
+          p5: sorted[Math.floor(n * 0.05)] ?? sorted[0],
+          p50: sorted[Math.floor(n * 0.5)] ?? sorted[0],
+          p95: sorted[Math.floor(n * 0.95)] ?? sorted[n - 1],
+        };
+      });
   }, [data]);
 
   const varRows = useMemo(() => {
     const rows = data?.charts.var_cvar ?? [];
-    return rows.filter((r) => r.confidence === 0.95);
+    const filtered = rows.filter((r) => Math.abs(r.confidence - confLevel) < 0.01);
+    return filtered.length ? filtered : rows;
+  }, [data, confLevel]);
+
+  const sortedFactors = useMemo(() => {
+    const factors = data?.charts.factor_decomposition ?? [];
+    return [...factors].sort((a, b) => Math.abs(b.weight_pct) - Math.abs(a.weight_pct));
   }, [data]);
 
   const metricCards = useMemo(() => {
@@ -167,6 +238,13 @@ export default function QuantDashboardPage() {
             : "—",
       },
     ];
+  }, [data]);
+
+  const regimeLabel = useMemo(() => {
+    const r = data?.quant_model?.regime_context ?? data?.context?.regime;
+    if (!r) return null;
+    if (typeof r === "string") return r;
+    return r.label ?? null;
   }, [data]);
 
   const alphaFeed = data?.charts.alpha_feed ?? [];
@@ -210,20 +288,30 @@ export default function QuantDashboardPage() {
         </div>
       ) : (
         <>
+          {/* Metric cards — color-coded by threshold */}
           <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
-            {metricCards.map((m) => (
-              <div
-                key={m.label}
-                className="rounded-xl border border-[#E2E8F0] bg-white px-4 py-3"
-              >
-                <p className="text-xs uppercase tracking-wider text-[#64748B]">
-                  {m.label}
-                </p>
-                <p className="mt-1 text-lg font-semibold text-[#0F172A]">{m.value}</p>
-              </div>
-            ))}
+            {metricCards.map((m) => {
+              const color = metricColor(m.label, m.value);
+              return (
+                <div
+                  key={m.label}
+                  className="rounded-xl border border-[#E2E8F0] bg-white px-4 py-3"
+                >
+                  <p className="text-xs uppercase tracking-wider text-[#64748B]">
+                    {m.label}
+                  </p>
+                  <p
+                    className="mt-1 text-lg font-semibold tabular-nums"
+                    style={{ color }}
+                  >
+                    {m.value}
+                  </p>
+                </div>
+              );
+            })}
           </div>
 
+          {/* Tab bar */}
           <div className="rounded-xl border border-[#E2E8F0] bg-white p-3">
             <div className="flex flex-wrap gap-2">
               {TABS.map((t) => {
@@ -247,49 +335,133 @@ export default function QuantDashboardPage() {
             </div>
           </div>
 
+          {/* ── Overview ─────────────────────────────────────────────── */}
           {tab === "Overview" ? (
             <div className="grid gap-4 lg:grid-cols-2">
-              <ChartCard title="Factor Decomposition">
-                <ResponsiveContainer width="100%" height={300}>
-                  <BarChart data={data.charts.factor_decomposition}>
-                    <CartesianGrid strokeDasharray="3 3" />
-                    <XAxis dataKey="factor" tick={{ fontSize: 12 }} />
-                    <YAxis tickFormatter={(v) => `${v}%`} />
-                    <Tooltip formatter={(v: number) => `${v}%`} />
-                    <Bar dataKey="weight_pct" fill="#1EB8CC" radius={[6, 6, 0, 0]} />
+              <ChartCard title="Factor Decomposition (Top Weights)">
+                <ResponsiveContainer width="100%" height={280}>
+                  <BarChart data={sortedFactors}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#F1F5F9" />
+                    <XAxis dataKey="factor" tick={{ fontSize: 11 }} />
+                    <YAxis tickFormatter={(v: number) => `${v}%`} />
+                    <Tooltip
+                      formatter={(v: number) => [`${(v as number).toFixed(2)}%`, "Weight"]}
+                    />
+                    <Bar dataKey="weight_pct" radius={[6, 6, 0, 0]}>
+                      {sortedFactors.map((_, idx) => (
+                        <Cell key={idx} fill={FACTOR_COLORS[idx % FACTOR_COLORS.length]} />
+                      ))}
+                    </Bar>
                   </BarChart>
                 </ResponsiveContainer>
               </ChartCard>
-              <ChartCard title="VaR / CVaR (95%)">
-                <ResponsiveContainer width="100%" height={300}>
-                  <LineChart data={varRows}>
-                    <CartesianGrid strokeDasharray="3 3" />
-                    <XAxis dataKey="horizon_days" />
-                    <YAxis tickFormatter={(v) => `${v}%`} />
-                    <Tooltip formatter={(v: number) => `${v}%`} />
-                    <Legend />
-                    <Line type="monotone" dataKey="var_pct" stroke="#0EA5E9" strokeWidth={2} />
-                    <Line type="monotone" dataKey="cvar_pct" stroke="#EF4444" strokeWidth={2} />
-                  </LineChart>
-                </ResponsiveContainer>
-              </ChartCard>
+
+              {regimeLabel ? (
+                <div className="rounded-xl border border-[#E2E8F0] bg-white p-5">
+                  <p className="text-xs uppercase tracking-wider text-[#64748B]">
+                    Regime Context
+                  </p>
+                  <p className="mt-2 text-2xl font-bold text-[#0F172A]">{regimeLabel}</p>
+                  <p className="mt-1 text-sm text-[#475569]">
+                    Confidence:{" "}
+                    {Math.round(
+                      (data.quant_model.regime_context?.confidence ?? 0) * 100,
+                    )}
+                    %
+                  </p>
+                  {data.context.recommendation_summary && (
+                    <p className="mt-3 text-sm leading-relaxed text-[#475569]">
+                      {data.context.recommendation_summary}
+                    </p>
+                  )}
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    {data.modes.map((m) => (
+                      <span
+                        key={m}
+                        className="rounded-full border border-[#BAE6FD] bg-[#F0F9FF] px-2.5 py-0.5 text-xs font-semibold text-[#0C4A6E]"
+                      >
+                        {m.toUpperCase()}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              ) : (
+                <ChartCard title="VaR / CVaR (95%)">
+                  <ResponsiveContainer width="100%" height={280}>
+                    <LineChart data={varRows}>
+                      <CartesianGrid strokeDasharray="3 3" stroke="#F1F5F9" />
+                      <XAxis dataKey="horizon_days" tickFormatter={(v) => `${v}d`} />
+                      <YAxis tickFormatter={(v: number) => `${v}%`} />
+                      <Tooltip formatter={(v: number) => [`${v.toFixed(2)}%`]} />
+                      <Legend />
+                      <Line
+                        type="monotone"
+                        dataKey="var_pct"
+                        name="VaR"
+                        stroke="#0EA5E9"
+                        strokeWidth={2}
+                        dot={false}
+                      />
+                      <Line
+                        type="monotone"
+                        dataKey="cvar_pct"
+                        name="CVaR"
+                        stroke="#EF4444"
+                        strokeWidth={2}
+                        dot={false}
+                      />
+                    </LineChart>
+                  </ResponsiveContainer>
+                </ChartCard>
+              )}
             </div>
           ) : null}
 
+          {/* ── Factor Analysis ───────────────────────────────────────── */}
           {tab === "Factor Analysis" ? (
-            <ChartCard title="Factor Decomposition">
-              <ResponsiveContainer width="100%" height={360}>
-                <BarChart data={data.charts.factor_decomposition}>
-                  <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis dataKey="factor" />
-                  <YAxis tickFormatter={(v) => `${v}%`} />
-                  <Tooltip formatter={(v: number) => `${v}%`} />
-                  <Bar dataKey="weight_pct" radius={[8, 8, 0, 0]}>
-                    {data.charts.factor_decomposition.map((entry, idx) => (
-                      <Cell
-                        key={`${entry.factor}-${idx}`}
-                        fill={idx % 2 === 0 ? "#1EB8CC" : "#0EA5E9"}
-                      />
+            <ChartCard title="Factor Decomposition — Sorted by Magnitude">
+              <ResponsiveContainer width="100%" height={380}>
+                <BarChart
+                  data={sortedFactors}
+                  layout="vertical"
+                  margin={{ left: 80, right: 24 }}
+                >
+                  <CartesianGrid strokeDasharray="3 3" stroke="#F1F5F9" horizontal={false} />
+                  <XAxis type="number" tickFormatter={(v: number) => `${v}%`} />
+                  <YAxis
+                    type="category"
+                    dataKey="factor"
+                    tick={{ fontSize: 11 }}
+                    width={80}
+                  />
+                  <Tooltip
+                    content={({ active, payload }) => {
+                      if (!active || !payload?.length) return null;
+                      const d = payload[0].payload as {
+                        factor: string;
+                        weight_pct: number;
+                      };
+                      const rank =
+                        sortedFactors.findIndex((f) => f.factor === d.factor) + 1;
+                      return (
+                        <div className="rounded-lg border border-[#E2E8F0] bg-white p-3 shadow-lg text-xs">
+                          <p className="font-semibold text-[#0F172A]">{d.factor}</p>
+                          <p className="mt-1 text-[#475569]">
+                            Weight:{" "}
+                            <span className="font-semibold text-[#1EB8CC]">
+                              {d.weight_pct.toFixed(2)}%
+                            </span>
+                          </p>
+                          <p className="mt-1 text-[#94A3B8]">
+                            Rank: #{rank} of {sortedFactors.length}
+                          </p>
+                        </div>
+                      );
+                    }}
+                  />
+                  <Bar dataKey="weight_pct" radius={[0, 6, 6, 0]}>
+                    {sortedFactors.map((_, idx) => (
+                      <Cell key={idx} fill={FACTOR_COLORS[idx % FACTOR_COLORS.length]} />
                     ))}
                   </Bar>
                 </BarChart>
@@ -297,81 +469,185 @@ export default function QuantDashboardPage() {
             </ChartCard>
           ) : null}
 
+          {/* ── Risk Surface ──────────────────────────────────────────── */}
           {tab === "Risk Surface" ? (
-            <div className="grid gap-4 lg:grid-cols-2">
-              <ChartCard title="VaR / CVaR Surface">
-                <ResponsiveContainer width="100%" height={330}>
-                  <BarChart data={data.charts.var_cvar}>
-                    <CartesianGrid strokeDasharray="3 3" />
-                    <XAxis
-                      dataKey="horizon_days"
-                      tickFormatter={(v) => `${v}d`}
-                    />
-                    <YAxis tickFormatter={(v) => `${v}%`} />
-                    <Tooltip
-                      formatter={(value: number) => `${value}%`}
-                      labelFormatter={(label, payload) => {
-                        const row = payload?.[0]?.payload as { confidence?: number };
-                        return `${label}d @ ${(row?.confidence ?? 0) * 100}%`;
-                      }}
-                    />
-                    <Legend />
-                    <Bar dataKey="var_pct" fill="#38BDF8" />
-                    <Bar dataKey="cvar_pct" fill="#F97316" />
-                  </BarChart>
-                </ResponsiveContainer>
-              </ChartCard>
-              <ChartCard title="Correlation Network">
-                <CorrelationNetwork
-                  nodes={network?.nodes ?? []}
-                  edges={network?.edges ?? []}
-                  activeNode={activeNode}
-                  onActiveNode={setActiveNode}
-                />
-              </ChartCard>
+            <div className="space-y-4">
+              {/* Confidence level selector */}
+              <div className="flex items-center gap-3 rounded-xl border border-[#E2E8F0] bg-white px-4 py-3">
+                <span className="text-xs font-semibold uppercase tracking-wider text-[#64748B]">
+                  Confidence Level
+                </span>
+                <div className="flex gap-2">
+                  {([0.9, 0.95, 0.99] as const).map((cl) => (
+                    <button
+                      key={cl}
+                      type="button"
+                      onClick={() => setConfLevel(cl)}
+                      className={[
+                        "rounded-md px-3 py-1 text-xs font-semibold transition",
+                        confLevel === cl
+                          ? "bg-[#1EB8CC] text-white"
+                          : "border border-[#E2E8F0] bg-white text-[#334155] hover:border-[#1EB8CC]",
+                      ].join(" ")}
+                    >
+                      {(cl * 100).toFixed(0)}%
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div className="grid gap-4 lg:grid-cols-2">
+                <ChartCard
+                  title={`VaR / CVaR Surface — ${(confLevel * 100).toFixed(0)}% Confidence`}
+                >
+                  <ResponsiveContainer width="100%" height={320}>
+                    <BarChart data={varRows}>
+                      <CartesianGrid strokeDasharray="3 3" stroke="#F1F5F9" />
+                      <XAxis dataKey="horizon_days" tickFormatter={(v) => `${v}d`} />
+                      <YAxis tickFormatter={(v: number) => `${v}%`} />
+                      <Tooltip
+                        formatter={(value: number, name: string) => [
+                          `${value.toFixed(2)}%`,
+                          name === "var_pct" ? "VaR" : "CVaR",
+                        ]}
+                        labelFormatter={(label) => `Horizon: ${label} days`}
+                      />
+                      <Legend
+                        formatter={(v) => (v === "var_pct" ? "VaR" : "CVaR")}
+                      />
+                      <Bar dataKey="var_pct" fill="#38BDF8" radius={[4, 4, 0, 0]} />
+                      <Bar dataKey="cvar_pct" fill="#F97316" radius={[4, 4, 0, 0]} />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </ChartCard>
+
+                <ChartCard title="Correlation Network">
+                  <CorrelationNetwork
+                    nodes={network?.nodes ?? []}
+                    edges={network?.edges ?? []}
+                    activeNode={activeNode}
+                    activeEdge={activeEdge}
+                    onActiveNode={setActiveNode}
+                    onActiveEdge={setActiveEdge}
+                  />
+                </ChartCard>
+              </div>
             </div>
           ) : null}
 
+          {/* ── Simulation ────────────────────────────────────────────── */}
           {tab === "Simulation" ? (
-            <ChartCard title="Monte Carlo Paths">
-              <ResponsiveContainer width="100%" height={360}>
-                <LineChart data={monteCarloRows}>
-                  <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis dataKey="day" />
+            <ChartCard title="Monte Carlo Simulation — P5 / Median / P95 Percentile Bands">
+              <ResponsiveContainer width="100%" height={380}>
+                <AreaChart
+                  data={monteCarloPercentiles}
+                  margin={{ top: 8, right: 24, bottom: 0, left: 0 }}
+                >
+                  <defs>
+                    <linearGradient id="mcBandFill" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="5%" stopColor="#1EB8CC" stopOpacity={0.15} />
+                      <stop offset="95%" stopColor="#1EB8CC" stopOpacity={0.02} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#F1F5F9" />
+                  <XAxis
+                    dataKey="day"
+                    label={{
+                      value: "Day",
+                      position: "insideBottomRight",
+                      offset: -4,
+                      fontSize: 11,
+                    }}
+                  />
                   <YAxis />
-                  <Tooltip />
-                  {(data.charts.monte_carlo_paths ?? []).slice(0, 12).map((p, idx) => (
-                    <Line
-                      key={p.path_id}
-                      type="monotone"
-                      dataKey={p.path_id}
-                      dot={false}
-                      stroke={idx === 0 ? "#0EA5E9" : "#94A3B8"}
-                      strokeWidth={idx === 0 ? 2 : 1}
-                    />
-                  ))}
-                </LineChart>
+                  <Tooltip
+                    content={({ active, payload, label }) => {
+                      if (!active || !payload?.length) return null;
+                      const d = payload[0]?.payload as {
+                        p5?: number;
+                        p50?: number;
+                        p95?: number;
+                      };
+                      return (
+                        <div className="rounded-lg border border-[#E2E8F0] bg-white p-3 shadow-lg text-xs">
+                          <p className="font-semibold text-[#0F172A]">
+                            Day {label}
+                          </p>
+                          <p className="mt-1 text-[#EF4444]">
+                            P5 (bear):{" "}
+                            {d.p5 != null ? d.p5.toFixed(2) : "—"}
+                          </p>
+                          <p className="mt-0.5 text-[#1EB8CC]">
+                            P50 (median):{" "}
+                            {d.p50 != null ? d.p50.toFixed(2) : "—"}
+                          </p>
+                          <p className="mt-0.5 text-[#16A34A]">
+                            P95 (bull):{" "}
+                            {d.p95 != null ? d.p95.toFixed(2) : "—"}
+                          </p>
+                        </div>
+                      );
+                    }}
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="p95"
+                    stroke="#16A34A"
+                    strokeWidth={2}
+                    fill="url(#mcBandFill)"
+                    name="P95 (Bull)"
+                    dot={false}
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="p50"
+                    stroke="#1EB8CC"
+                    strokeWidth={2.5}
+                    fill="transparent"
+                    name="P50 (Median)"
+                    dot={false}
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="p5"
+                    stroke="#EF4444"
+                    strokeWidth={2}
+                    fill="transparent"
+                    name="P5 (Bear)"
+                    dot={false}
+                  />
+                  <Legend />
+                </AreaChart>
               </ResponsiveContainer>
             </ChartCard>
           ) : null}
 
+          {/* ── Macro ─────────────────────────────────────────────────── */}
           {tab === "Macro" ? (
             <div className="grid gap-4 md:grid-cols-2">
               <div className="rounded-xl border border-[#E2E8F0] bg-white p-5">
-                <p className="text-xs uppercase tracking-wider text-[#64748B]">Regime Context</p>
-                <p className="mt-2 text-2xl font-semibold text-[#0F172A]">
-                  {data.quant_model.regime_context?.label || "Neutral"}
+                <p className="text-xs uppercase tracking-wider text-[#64748B]">
+                  Regime Context
+                </p>
+                <p className="mt-2 text-2xl font-bold text-[#0F172A]">
+                  {data.quant_model.regime_context?.label ?? "Neutral"}
                 </p>
                 <p className="mt-2 text-sm text-[#475569]">
-                  Confidence: {Math.round((data.quant_model.regime_context?.confidence || 0) * 100)}%
+                  Confidence:{" "}
+                  {Math.round(
+                    (data.quant_model.regime_context?.confidence ?? 0) * 100,
+                  )}
+                  %
                 </p>
-                <p className="mt-4 text-sm text-[#475569]">
-                  {data.context.recommendation_summary ||
+                <p className="mt-4 text-sm leading-relaxed text-[#475569]">
+                  {data.context.recommendation_summary ??
                     "Macro positioning summary will appear after latest Swarm synthesis."}
                 </p>
               </div>
               <div className="rounded-xl border border-[#E2E8F0] bg-white p-5">
-                <p className="text-xs uppercase tracking-wider text-[#64748B]">Active Quant Modes</p>
+                <p className="text-xs uppercase tracking-wider text-[#64748B]">
+                  Active Quant Modes
+                </p>
                 <div className="mt-3 flex flex-wrap gap-2">
                   {data.modes.map((m) => (
                     <span
@@ -383,39 +659,75 @@ export default function QuantDashboardPage() {
                   ))}
                 </div>
                 <p className="mt-4 text-sm text-[#475569]">
-                  Forecast horizon: {data.quant_model.forecast?.horizon_days ?? "—"} days.
-                  Volatility shift: {data.quant_model.forecast?.volatility_shift_pct_vs_baseline ?? "—"}%.
+                  Forecast horizon:{" "}
+                  {data.quant_model.forecast?.horizon_days ?? "—"} days. Volatility
+                  shift:{" "}
+                  {data.quant_model.forecast?.volatility_shift_pct_vs_baseline ?? "—"}
+                  %.
                 </p>
               </div>
             </div>
           ) : null}
 
+          {/* ── Alpha ─────────────────────────────────────────────────── */}
           {tab === "Alpha" ? (
             <div className="rounded-xl border border-[#E2E8F0] bg-white p-5">
-              <div className="mb-3 flex items-center justify-between gap-2">
+              <div className="mb-4 flex items-center justify-between gap-2">
                 <h3 className="text-sm font-semibold text-[#0F172A]">
                   Alpha Opportunity Feed
                 </h3>
-                <Link href="/dashboard/swarm" className="text-xs text-[#0EA5E9] hover:underline">
+                <Link
+                  href="/dashboard/swarm"
+                  className="text-xs text-[#0EA5E9] hover:underline"
+                >
                   Run full swarm
                 </Link>
               </div>
-              <div className="space-y-2">
+              <div className="space-y-3">
                 {alphaFeed.length ? (
-                  alphaFeed.map((row, idx) => (
-                    <div
-                      key={`${row.symbol}-${idx}`}
-                      className="rounded-lg border border-[#E2E8F0] bg-[#FAFCFE] px-3 py-2"
-                    >
-                      <div className="flex items-center justify-between">
-                        <p className="text-sm font-semibold text-[#0F172A]">{row.symbol}</p>
-                        <p className="text-xs font-medium text-[#0C4A6E]">{row.confidence.toFixed(1)}% confidence</p>
+                  alphaFeed.map((row, idx) => {
+                    const confPct =
+                      row.confidence <= 1
+                        ? row.confidence * 100
+                        : row.confidence;
+                    const { text, bar, border } = alphaConfidenceColors(
+                      row.confidence,
+                    );
+                    return (
+                      <div
+                        key={`${row.symbol}-${idx}`}
+                        className="rounded-lg border bg-[#FAFCFE] px-4 py-3"
+                        style={{ borderColor: border }}
+                      >
+                        <div className="flex items-center justify-between gap-2">
+                          <p className="text-sm font-semibold text-[#0F172A]">
+                            {row.symbol}
+                          </p>
+                          <p
+                            className="text-xs font-semibold tabular-nums"
+                            style={{ color: text }}
+                          >
+                            {confPct.toFixed(0)}% confidence
+                          </p>
+                        </div>
+                        {/* Confidence progress bar */}
+                        <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-[#F1F5F9]">
+                          <div
+                            className="h-full rounded-full transition-all"
+                            style={{
+                              width: `${Math.min(100, confPct)}%`,
+                              background: bar,
+                            }}
+                          />
+                        </div>
+                        <p className="mt-2 text-sm text-[#475569]">{row.reason}</p>
                       </div>
-                      <p className="mt-1 text-sm text-[#475569]">{row.reason}</p>
-                    </div>
-                  ))
+                    );
+                  })
                 ) : (
-                  <p className="text-sm text-[#64748B]">No alpha opportunities available.</p>
+                  <p className="text-sm text-[#64748B]">
+                    No alpha opportunities available.
+                  </p>
                 )}
               </div>
             </div>
@@ -439,43 +751,59 @@ function CorrelationNetwork({
   nodes,
   edges,
   activeNode,
+  activeEdge,
   onActiveNode,
+  onActiveEdge,
 }: {
   nodes: Array<{ id: string; label: string; weight_pct: number }>;
   edges: Array<{ source: string; target: string; correlation: number }>;
   activeNode: string | null;
+  activeEdge: { source: string; target: string; correlation: number } | null;
   onActiveNode: (id: string | null) => void;
+  onActiveEdge: (
+    edge: { source: string; target: string; correlation: number } | null,
+  ) => void;
 }) {
   const graph = useMemo(() => {
     const cx = 180;
     const cy = 160;
     const radius = 110;
+    const maxWeight = Math.max(...nodes.map((n) => n.weight_pct || 1), 1);
     const nodePos = nodes.map((n, i) => {
       const angle = (i / Math.max(nodes.length, 1)) * Math.PI * 2;
+      // Node size 8–20 proportional to portfolio weight
+      const r = 8 + ((n.weight_pct || 0) / maxWeight) * 12;
       return {
         ...n,
         x: cx + Math.cos(angle) * radius,
         y: cy + Math.sin(angle) * radius,
+        r,
       };
     });
     return { nodePos };
   }, [nodes]);
 
-  const connected = useMemo(() => {
+  const visibleEdges = useMemo(() => {
     if (!activeNode) return edges;
-    return edges.filter((e) => e.source === activeNode || e.target === activeNode);
+    return edges.filter(
+      (e) => e.source === activeNode || e.target === activeNode,
+    );
   }, [edges, activeNode]);
 
   const findNode = (id: string) => graph.nodePos.find((n) => n.id === id);
 
   return (
-    <div className="grid gap-3 lg:grid-cols-[1fr_220px]">
-      <svg viewBox="0 0 360 320" className="h-[320px] w-full rounded-md bg-[#F8FAFC]">
-        {connected.map((e, idx) => {
+    <div className="grid gap-3 lg:grid-cols-[1fr_200px]">
+      <svg
+        viewBox="0 0 360 320"
+        className="h-[300px] w-full rounded-md bg-[#F8FAFC]"
+      >
+        {visibleEdges.map((e, idx) => {
           const src = findNode(e.source);
           const dst = findNode(e.target);
           if (!src || !dst) return null;
-          const strong = Math.abs(e.correlation) > 0.7;
+          const isActive =
+            activeEdge?.source === e.source && activeEdge?.target === e.target;
           return (
             <line
               key={`${e.source}-${e.target}-${idx}`}
@@ -483,9 +811,12 @@ function CorrelationNetwork({
               y1={src.y}
               x2={dst.x}
               y2={dst.y}
-              stroke={strong ? "#EF4444" : "#94A3B8"}
-              strokeWidth={Math.max(1, Math.abs(e.correlation) * 3)}
-              opacity={0.75}
+              stroke={edgeStroke(e.correlation)}
+              strokeWidth={isActive ? 3 : Math.max(1, Math.abs(e.correlation) * 3)}
+              opacity={isActive ? 1 : 0.6}
+              style={{ cursor: "pointer" }}
+              onMouseEnter={() => onActiveEdge(e)}
+              onMouseLeave={() => onActiveEdge(null)}
             />
           );
         })}
@@ -496,18 +827,19 @@ function CorrelationNetwork({
               key={n.id}
               onMouseEnter={() => onActiveNode(n.id)}
               onMouseLeave={() => onActiveNode(null)}
+              style={{ cursor: "pointer" }}
             >
               <circle
                 cx={n.x}
                 cy={n.y}
-                r={active ? 16 : 12}
+                r={active ? n.r + 4 : n.r}
                 fill={active ? "#0EA5E9" : "#1E293B"}
               />
               <text
                 x={n.x}
                 y={n.y + 4}
                 textAnchor="middle"
-                fontSize="9"
+                fontSize="8"
                 fill="#FFFFFF"
               >
                 {n.label}
@@ -517,18 +849,47 @@ function CorrelationNetwork({
         })}
       </svg>
 
-      <div className="rounded-md border border-[#E2E8F0] bg-[#FAFCFE] p-3">
-        {activeNode ? (
+      <div className="rounded-md border border-[#E2E8F0] bg-[#FAFCFE] p-3 text-xs">
+        {activeEdge ? (
           <>
-            <p className="text-xs uppercase tracking-wider text-[#64748B]">Hovered Symbol</p>
-            <p className="mt-1 text-base font-semibold text-[#0F172A]">{activeNode}</p>
-            <p className="mt-2 text-xs text-[#475569]">
-              {connected.length} active correlation links visible.
+            <p className="font-semibold uppercase tracking-wider text-[#64748B]">
+              Edge Details
+            </p>
+            <p className="mt-1 font-semibold text-[#0F172A]">
+              {activeEdge.source} ↔ {activeEdge.target}
+            </p>
+            <p className="mt-1 text-[#475569]">
+              Correlation:{" "}
+              <span
+                className="font-semibold"
+                style={{ color: edgeStroke(activeEdge.correlation) }}
+              >
+                {activeEdge.correlation.toFixed(3)}
+              </span>
+            </p>
+            <p className="mt-1 text-[#94A3B8]">
+              {Math.abs(activeEdge.correlation) > 0.7
+                ? "High — cluster risk"
+                : Math.abs(activeEdge.correlation) > 0.4
+                  ? "Moderate correlation"
+                  : "Low correlation"}
+            </p>
+          </>
+        ) : activeNode ? (
+          <>
+            <p className="font-semibold uppercase tracking-wider text-[#64748B]">
+              Node: {activeNode}
+            </p>
+            <p className="mt-1 text-[#475569]">
+              {visibleEdges.length} correlation links.
+            </p>
+            <p className="mt-1 text-[#94A3B8]">
+              Node size reflects portfolio weight.
             </p>
           </>
         ) : (
-          <p className="text-xs text-[#64748B]">
-            Hover a node to inspect connected correlation edges and cluster pressure.
+          <p className="text-[#64748B]">
+            Hover a node or edge to inspect correlations and cluster pressure.
           </p>
         )}
       </div>

--- a/neufin-web/components/dashboard/DashboardModeControls.tsx
+++ b/neufin-web/components/dashboard/DashboardModeControls.tsx
@@ -15,6 +15,12 @@ const MODE_LABELS: Record<DashboardMode, string> = {
   advisor: "Advisor Mode",
 };
 
+const MODE_DESCRIPTIONS: Record<DashboardMode, string> = {
+  cio: "Risk budget · Regime · Institutional metrics",
+  trader: "Signal feed · Alpha · Execution metrics",
+  advisor: "Client narrative · Tax harvest · Memo readiness",
+};
+
 export default function DashboardModeControls({
   advancedQuantMode,
   dashboardMode,
@@ -58,13 +64,23 @@ export default function DashboardModeControls({
                 type="button"
                 onClick={() => onModeChange(mode)}
                 className={[
-                  "rounded-lg border px-3 py-1.5 text-xs font-semibold transition",
+                  "rounded-lg border px-3 py-2 text-left transition",
                   active
-                    ? "border-[#1EB8CC] bg-[#E0F7FA] text-[#0B5561]"
-                    : "border-[#D1D5DB] bg-white text-[#334155] hover:border-[#94A3B8]",
+                    ? "border-[#1EB8CC] bg-[#E0F7FA]"
+                    : "border-[#D1D5DB] bg-white hover:border-[#94A3B8]",
                 ].join(" ")}
               >
-                {MODE_LABELS[mode]}
+                <p
+                  className={[
+                    "text-xs font-semibold",
+                    active ? "text-[#0B5561]" : "text-[#334155]",
+                  ].join(" ")}
+                >
+                  {MODE_LABELS[mode]}
+                </p>
+                <p className="mt-0.5 text-[11px] text-[#94A3B8]">
+                  {MODE_DESCRIPTIONS[mode]}
+                </p>
               </button>
             );
           })}

--- a/neufin-web/components/dashboard/GenerateIcReportButton.tsx
+++ b/neufin-web/components/dashboard/GenerateIcReportButton.tsx
@@ -7,6 +7,7 @@ import { apiFetch, apiGet, apiPost } from "@/lib/api-client";
 import { stripeSuccessUrlReports } from "@/lib/stripe-checkout-urls";
 import {
   getStoredReportTheme,
+  getStoredReportMode,
   type ReportTheme,
 } from "@/components/dashboard/ReportThemeModal";
 
@@ -53,6 +54,7 @@ export function GenerateIcReportButton({
             portfolio_id: portfolioId,
             advisor_name: "NeuFin",
             theme: resolvedTheme,
+            report_mode: getStoredReportMode(),
           }),
         });
         if (!res.ok) {

--- a/neufin-web/components/dashboard/ReportThemeModal.tsx
+++ b/neufin-web/components/dashboard/ReportThemeModal.tsx
@@ -3,8 +3,10 @@
 import { useEffect, useState } from "react";
 
 export type ReportTheme = "dark" | "light";
+export type ReportMode = "standard" | "ic_memo" | "advisor_report";
 
 const STORAGE_KEY = "neufin-report-theme";
+const MODE_STORAGE_KEY = "neufin-report-mode";
 
 export function getStoredReportTheme(): ReportTheme {
   if (typeof window === "undefined") return "light";
@@ -18,13 +20,50 @@ export function storeReportTheme(theme: ReportTheme) {
   }
 }
 
+export function getStoredReportMode(): ReportMode {
+  if (typeof window === "undefined") return "standard";
+  const v = localStorage.getItem(MODE_STORAGE_KEY);
+  return v === "standard" || v === "ic_memo" || v === "advisor_report" ? v : "standard";
+}
+
+export function storeReportMode(mode: ReportMode) {
+  if (typeof window !== "undefined") {
+    localStorage.setItem(MODE_STORAGE_KEY, mode);
+  }
+}
+
+const REPORT_MODES: Array<{
+  value: ReportMode;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: "standard",
+    label: "Standard Report",
+    description: "Full portfolio briefing with all sections",
+  },
+  {
+    value: "ic_memo",
+    label: "IC Memo",
+    description: "Institutional committee format · concise executive + risk",
+  },
+  {
+    value: "advisor_report",
+    label: "Advisor Report",
+    description: "Client-ready narrative with institutional diagnostics",
+  },
+];
+
 interface ReportThemeModalProps {
-  onSelect: (theme: ReportTheme) => void;
+  onSelect: (theme: ReportTheme, mode: ReportMode) => void;
   onClose: () => void;
 }
 
 export function ReportThemeModal({ onSelect, onClose }: ReportThemeModalProps) {
   const [hovered, setHovered] = useState<ReportTheme | null>(null);
+  const [selectedMode, setSelectedMode] = useState<ReportMode>(
+    getStoredReportMode(),
+  );
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
@@ -36,7 +75,8 @@ export function ReportThemeModal({ onSelect, onClose }: ReportThemeModalProps) {
 
   const handleSelect = (theme: ReportTheme) => {
     storeReportTheme(theme);
-    onSelect(theme);
+    storeReportMode(selectedMode);
+    onSelect(theme, selectedMode);
   };
 
   return (
@@ -243,6 +283,40 @@ export function ReportThemeModal({ onSelect, onClose }: ReportThemeModalProps) {
         >
           Cancel
         </button>
+
+        {/* Report mode selector */}
+        <div style={{ marginTop: 24 }}>
+          <div style={{ color: "#F0F4FF", fontSize: 13, fontWeight: 700, marginBottom: 12 }}>
+            Report Mode
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            {REPORT_MODES.map((rm) => {
+              const active = selectedMode === rm.value;
+              return (
+                <button
+                  key={rm.value}
+                  onClick={() => setSelectedMode(rm.value)}
+                  style={{
+                    padding: "10px 14px",
+                    borderRadius: 10,
+                    background: active ? "#0B1929" : "transparent",
+                    border: `2px solid ${active ? "#1EB8CC" : "#2A3550"}`,
+                    cursor: "pointer",
+                    textAlign: "left",
+                    transition: "border-color 0.15s",
+                  }}
+                >
+                  <div style={{ color: "#F0F4FF", fontSize: 12, fontWeight: 600 }}>
+                    {rm.label}
+                  </div>
+                  <div style={{ color: "#64748B", fontSize: 11, marginTop: 2 }}>
+                    {rm.description}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

### Financial Model Studio (`FinancialModelSelector.tsx`)
- 7 selectable financial objective modes: Alpha Generation, Risk Minimization, Volatility Forecast, Macro Regime, Long-Term Allocation, Short-Term Trading, Hybrid Institutional (default)
- Multi-select up to 3 modes; no ML model names exposed — financial objectives only
- Hover tooltips explain financial impact (not model internals)
- Preview Impact section: expected Sharpe, volatility %, drawdown %, DNA score shifts
- Persists to `user_preferences.quant_models` in Supabase with localStorage fallback
- Integrated in `/dashboard/portfolio` (collapsed by default) and `/swarm`
- Backward compatible: defaults to Hybrid Institutional if user has not interacted

### Quant Dashboard (`/dashboard/quant`)
- 6 interactive tabs: Overview, Factor Analysis, Risk Surface, Simulation, Macro, Alpha
- AreaChart with P5/P50/P95 percentile bands for Monte Carlo simulation
- Confidence level selector (90%/95%/99%) for VaR/CVaR Risk Surface
- Horizontal factor bar chart sorted by magnitude with custom tooltips
- Correlation network: node size by weight%, edge colour by correlation strength, hover shows exact value

### IC Report Modes
- Report Mode selector in theme modal: Standard / IC Memo / Advisor Report
- Mode persisted to localStorage, passed as `report_mode` to `/api/reports/generate`
- `pdf_generator.py`: new `_page_quant_model_outputs()` page inserted between behavioral DNA and stress testing. Syntax verified.

### Dashboard Modes
- CIO / Trader / Advisor mode widgets with data-driven sub-labels
- Mode buttons show description text

## Checklist
- [x] No ML model names exposed to users
- [x] Backward compatible
- [x] TypeScript: 0 errors across all modified files
- [x] PDF syntax verified
- [x] Supabase upsert with onConflict: user_id