### PR TITLE
promote: develop to main (admin access endpoint stabilization)

### DIFF
--- a/neufin-backend/routers/admin.py
+++ b/neufin-backend/routers/admin.py
@@ -7,6 +7,7 @@ Ops (advisor OR is_admin):
   POST /api/admin/users/{user_id}/resend-onboarding
 
 Admin only (is_admin):
+  GET  /api/admin/access
   GET  /api/admin/dashboard
   POST /api/admin/users/{user_id}/plan
   POST /api/admin/users/{user_id}/suspend
@@ -153,6 +154,11 @@ def _delta_pct(current: float, previous: float) -> float | None:
 
 
 # ── Dashboard ────────────────────────────────────────────────────────────────
+
+
+@router.get("/api/admin/access")
+async def admin_access(_user: JWTUser = Depends(get_admin_user)):
+    return {"ok": True}
 
 
 @router.get("/api/admin/dashboard")

--- a/neufin-web/app/admin/layout.tsx
+++ b/neufin-web/app/admin/layout.tsx
@@ -14,7 +14,7 @@ async function checkAdminAccess(token: string): Promise<"ok" | "unauthorized" | 
   }
 
   try {
-    const response = await fetch(`${base}/api/admin/dashboard`, {
+    const response = await fetch(`${base}/api/admin/access`, {
       method: "GET",
       headers: {
         Authorization: token.startsWith("Bearer ") ? token : `Bearer ${token}`,

--- a/neufin-web/app/api/admin/access/route.ts
+++ b/neufin-web/app/api/admin/access/route.ts
@@ -1,0 +1,8 @@
+import { NextRequest } from "next/server";
+import { proxyBackendJson } from "@/lib/admin-backend-proxy";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  return proxyBackendJson(req, "/api/admin/access", { method: "GET" });
+}

--- a/neufin-web/middleware.ts
+++ b/neufin-web/middleware.ts
@@ -126,10 +126,12 @@ async function hasAdminRole(token: string): Promise<boolean> {
   if (!BACKEND_API_URL) return true;
   try {
     const res = await fetch(
-      `${BACKEND_API_URL.replace(/\/$/, "")}/api/admin/dashboard`,
+      `${BACKEND_API_URL.replace(/\/$/, "")}/api/admin/access`,
       {
         method: "GET",
-        headers: { Authorization: `Bearer ${token}` },
+        headers: {
+          Authorization: token.startsWith("Bearer ") ? token : `Bearer ${token}`,
+        },
         cache: "no-store",
       },
     );


### PR DESCRIPTION
Summary:\n- promote the latest develop commits to main\n- includes the dedicated backend admin access-check endpoint merged via PR #77\n- keeps admin gating auth-only so dashboard data failures no longer redirect valid admins to /dashboard\n\nCommits in this promotion:\n- 6f7a4f7 Merge pull request #77 from stealthg0dd/copilot/fix-admin-redirect-issue\n- a6cc751 fix: use dedicated admin access endpoint for /admin gating\n\nDeploy behavior:\n- once this PR is reviewed and merged to main, the existing main push workflows will deploy to production automatically