### PR TITLE
fix: Admin panel access - add default ADMIN_EMAILS

### DIFF
--- a/neufin-backend/.env.example
+++ b/neufin-backend/.env.example
@@ -63,6 +63,11 @@ LOG_FORMAT=console
 # DEBUG | INFO | WARNING | ERROR
 LOG_LEVEL=INFO
 
+# ── Admin access control ─────────────────────────────────────────────────────
+# Comma-separated email addresses that always have admin access to /admin panel.
+# Users in this list bypass the is_admin DB column check.
+ADMIN_EMAILS=stealthgodd@gmail.com,info@neufin.ai
+
 # ── Market data providers (all optional — app degrades gracefully) ────────────
 # Polygon.io — primary batch price source. polygon.io → Dashboard → API Keys.
 POLYGON_API_KEY=

--- a/neufin-backend/core/config.py
+++ b/neufin-backend/core/config.py
@@ -165,7 +165,7 @@ class Settings(BaseSettings):
 
     # ── Admin access control ─────────────────────────────────────────────────
     ADMIN_EMAILS: str = Field(
-        default="",
+        default="stealthgodd@gmail.com,info@neufin.ai",
         description=(
             "Comma-separated list of email addresses that always have is_admin access, "
             "regardless of the user_profiles.is_admin DB column. "


### PR DESCRIPTION
## Problem

The /admin panel was redirecting to /dashboard even for valid admin users because:
- ADMIN_EMAILS env var was empty/not set in production
- Users did not have `is_admin=true` in the database

## Solution

Added default admin emails directly in code:
- `stealthgodd@gmail.com`
- `info@neufin.ai`

These emails now bypass the `is_admin` DB column check automatically.

## Changes

- `core/config.py`: Set default ADMIN_EMAILS
- `.env.example`: Documented ADMIN_EMAILS for future reference

## How it works

1. User visits /admin
2. Middleware calls backend /api/admin/access
3. Backend checks if user email is in `settings.admin_emails_set`
4. If email matches default list → access granted
5. If not, falls back to checking `is_admin` column in DB

## Testing

After merge to main and deploy:
1. Go to https://www.neufin.ai/admin
2. Should see admin dashboard instead of redirect to /dashboard