### PR TITLE
fix(lint): resolve ruff errors in risk services

### DIFF
--- a/neufin-backend/routers/risk.py
+++ b/neufin-backend/routers/risk.py
@@ -88,8 +88,8 @@ async def get_behavioral_drift(
         logger.error("risk.behavioral_drift.error", error=str(e))
         raise HTTPException(
             status_code=500,
-            detail=f"Behavioral drift analysis failed: {str(e)}",
-        )
+            detail=f"Behavioral drift analysis failed: {e!s}",
+        ) from None
 
 
 @router.post("/behavioral-drift")
@@ -127,8 +127,8 @@ async def analyze_behavioral_drift(
         logger.error("risk.behavioral_drift.error", error=str(e))
         raise HTTPException(
             status_code=500,
-            detail=f"Behavioral drift analysis failed: {str(e)}",
-        )
+            detail=f"Behavioral drift analysis failed: {e!s}",
+        ) from None
 
 
 @router.get("/cross-portfolio")
@@ -158,8 +158,8 @@ async def get_cross_portfolio(
         logger.error("risk.cross_portfolio.error", error=str(e))
         raise HTTPException(
             status_code=500,
-            detail=f"Cross-portfolio analysis failed: {str(e)}",
-        )
+            detail=f"Cross-portfolio analysis failed: {e!s}",
+        ) from None
 
 
 @router.post("/cross-portfolio")
@@ -196,8 +196,8 @@ async def analyze_cross_portfolio_endpoint(
         logger.error("risk.cross_portfolio.error", error=str(e))
         raise HTTPException(
             status_code=500,
-            detail=f"Cross-portfolio analysis failed: {str(e)}",
-        )
+            detail=f"Cross-portfolio analysis failed: {e!s}",
+        ) from None
 
 
 @router.get("/health")

--- a/neufin-backend/services/behavioral_drift_detector.py
+++ b/neufin-backend/services/behavioral_drift_detector.py
@@ -12,8 +12,7 @@ detect_behavioral_drift(user_id, portfolio_history, documented_risk_profile) -> 
 
 from __future__ import annotations
 
-import math
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Any
 
 import structlog

--- a/neufin-backend/services/cross_portfolio_analyzer.py
+++ b/neufin-backend/services/cross_portfolio_analyzer.py
@@ -16,7 +16,6 @@ analyze_cross_portfolio(user_id, portfolios, market_data) -> dict
 
 from __future__ import annotations
 
-import math
 from typing import Any
 
 import numpy as np


### PR DESCRIPTION
## Fix

Resolves ruff linting errors from PR #80:

- Remove unused imports (`math`, `timedelta`)
- Use `raise ... from None` for exception chaining (B904)
- Use conversion flag `{esudo apt-get update && sudo apt-get install -y libcairo2 libpango-1.0-0 libpangocairo-1.0-0}` instead of `{str(e)}` (RUF010)

All ruff checks now pass.