### PR TITLE
fix(ui): design refresh — logo, contrast, SEA markets, currency detection

### DIFF
--- a/neufin-backend/requirements.txt
+++ b/neufin-backend/requirements.txt
@@ -17,6 +17,7 @@ supabase-functions==2.28.0
 # Data
 pandas==2.2.3
 numpy==2.2.4
+yfinance>=0.2.40
 
 # PDF generation (Pillow enables reportlab.graphics.renderPM for charts)
 reportlab==4.2.5

--- a/neufin-backend/routers/market.py
+++ b/neufin-backend/routers/market.py
@@ -5,6 +5,7 @@ Aggregated, anonymised statistics across all Neufin portfolios.
 
 GET /api/market/health           → platform-wide DNA stats (5-min cache)
 GET /api/market/score-trend      → avg DNA score per day, last 30 days (5-min cache)
+GET /api/market/indices          → live global index quotes (SEA + US, 5-min cache)
 POST /api/analytics/track        → client-side funnel event ingestion
 """
 
@@ -199,6 +200,98 @@ async def score_trend():
 
     payload = {"trend": trend}
     _store("score_trend", payload)
+    return payload
+
+
+# ── Global index quotes (SEA + US) ────────────────────────────────────────────
+
+# Yahoo Finance symbols for each display label
+_INDEX_MAP: dict[str, dict] = {
+    "S&P 500":  {"symbol": "^GSPC",    "currency": "USD", "region": "US"},
+    "NASDAQ":   {"symbol": "^IXIC",    "currency": "USD", "region": "US"},
+    "FTSE 100": {"symbol": "^FTSE",    "currency": "GBP", "region": "UK"},
+    "STI":      {"symbol": "^STI",     "currency": "SGD", "region": "SG"},
+    "VNIndex":  {"symbol": "^VNINDEX", "currency": "VND", "region": "VN"},
+    "KLCI":     {"symbol": "^KLSE",    "currency": "MYR", "region": "MY"},
+    "SET":      {"symbol": "^SET.BK",  "currency": "THB", "region": "TH"},
+    "HSI":      {"symbol": "^HSI",     "currency": "HKD", "region": "HK"},
+}
+
+_INDEX_CACHE_TTL = 300  # 5 minutes
+
+
+def _fetch_index_quotes() -> list[dict]:
+    """Fetch latest quotes for all tracked indices using yfinance."""
+    try:
+        import yfinance as yf  # noqa: PLC0415
+    except ImportError:
+        logger.warning("market.indices_yfinance_missing")
+        return []
+
+    symbols = [v["symbol"] for v in _INDEX_MAP.values()]
+    labels = {v["symbol"]: k for k, v in _INDEX_MAP.items()}
+
+    try:
+        tickers = yf.Tickers(" ".join(symbols))
+        results = []
+        for sym in symbols:
+            label = labels[sym]
+            meta = _INDEX_MAP[label]
+            try:
+                info = tickers.tickers[sym].fast_info
+                price = float(getattr(info, "last_price", None) or 0)
+                prev_close = float(getattr(info, "previous_close", None) or 0)
+                change_pct = (
+                    round((price - prev_close) / prev_close * 100, 2)
+                    if prev_close and prev_close > 0
+                    else None
+                )
+                results.append(
+                    {
+                        "label": label,
+                        "symbol": sym,
+                        "price": round(price, 2) if price > 0 else None,
+                        "change_pct": change_pct,
+                        "currency": meta["currency"],
+                        "region": meta["region"],
+                        "status": "live" if price > 0 else "unavailable",
+                    }
+                )
+            except Exception as exc:
+                logger.warning(
+                    "market.index_quote_failed", symbol=sym, error=str(exc)
+                )
+                results.append(
+                    {
+                        "label": label,
+                        "symbol": sym,
+                        "price": None,
+                        "change_pct": None,
+                        "currency": meta["currency"],
+                        "region": meta["region"],
+                        "status": "unavailable",
+                    }
+                )
+        return results
+    except Exception as exc:
+        logger.warning("market.indices_batch_failed", error=str(exc))
+        return []
+
+
+@router.get("/api/market/indices")
+async def market_indices():
+    """
+    Live quotes for all tracked global indices (US + SEA).
+    Cached for 5 minutes. Falls back to empty list if yfinance unavailable.
+    """
+    hit, cached = _cached("market_indices", ttl=_INDEX_CACHE_TTL)
+    if hit:
+        return cached
+
+    import asyncio
+    quotes = await asyncio.to_thread(_fetch_index_quotes)
+    payload = {"indices": quotes, "count": len(quotes)}
+    _store("market_indices", payload)
     return payload
 
 

--- a/neufin-backend/routers/market.py
+++ b/neufin-backend/routers/market.py
@@ -223,7 +223,7 @@ _INDEX_CACHE_TTL = 300  # 5 minutes
 def _fetch_index_quotes() -> list[dict]:
     """Fetch latest quotes for all tracked indices using yfinance."""
     try:
-        import yfinance as yf  # noqa: PLC0415
+        import yfinance as yf
     except ImportError:
         logger.warning("market.indices_yfinance_missing")
         return []

--- a/neufin-backend/routers/market.py
+++ b/neufin-backend/routers/market.py
@@ -207,14 +207,14 @@ async def score_trend():
 
 # Yahoo Finance symbols for each display label
 _INDEX_MAP: dict[str, dict] = {
-    "S&P 500":  {"symbol": "^GSPC",    "currency": "USD", "region": "US"},
-    "NASDAQ":   {"symbol": "^IXIC",    "currency": "USD", "region": "US"},
-    "FTSE 100": {"symbol": "^FTSE",    "currency": "GBP", "region": "UK"},
-    "STI":      {"symbol": "^STI",     "currency": "SGD", "region": "SG"},
-    "VNIndex":  {"symbol": "^VNINDEX", "currency": "VND", "region": "VN"},
-    "KLCI":     {"symbol": "^KLSE",    "currency": "MYR", "region": "MY"},
-    "SET":      {"symbol": "^SET.BK",  "currency": "THB", "region": "TH"},
-    "HSI":      {"symbol": "^HSI",     "currency": "HKD", "region": "HK"},
+    "S&P 500": {"symbol": "^GSPC", "currency": "USD", "region": "US"},
+    "NASDAQ": {"symbol": "^IXIC", "currency": "USD", "region": "US"},
+    "FTSE 100": {"symbol": "^FTSE", "currency": "GBP", "region": "UK"},
+    "STI": {"symbol": "^STI", "currency": "SGD", "region": "SG"},
+    "VNIndex": {"symbol": "^VNINDEX", "currency": "VND", "region": "VN"},
+    "KLCI": {"symbol": "^KLSE", "currency": "MYR", "region": "MY"},
+    "SET": {"symbol": "^SET.BK", "currency": "THB", "region": "TH"},
+    "HSI": {"symbol": "^HSI", "currency": "HKD", "region": "HK"},
 }
 
 _INDEX_CACHE_TTL = 300  # 5 minutes
@@ -258,9 +258,7 @@ def _fetch_index_quotes() -> list[dict]:
                     }
                 )
             except Exception as exc:
-                logger.warning(
-                    "market.index_quote_failed", symbol=sym, error=str(exc)
-                )
+                logger.warning("market.index_quote_failed", symbol=sym, error=str(exc))
                 results.append(
                     {
                         "label": label,
@@ -289,6 +287,7 @@ async def market_indices():
         return cached
 
     import asyncio
+
     quotes = await asyncio.to_thread(_fetch_index_quotes)
     payload = {"indices": quotes, "count": len(quotes)}
     _store("market_indices", payload)

--- a/neufin-backend/services/calculator.py
+++ b/neufin-backend/services/calculator.py
@@ -973,19 +973,19 @@ def _fetch_prices(symbols: list[str], period: str) -> pd.DataFrame:
 # ── Currency detection ────────────────────────────────────────────────────────
 # Maps ticker exchange suffix → ISO 4217 currency code.
 _SUFFIX_CURRENCY: dict[str, str] = {
-    ".SI": "SGD",   # Singapore Exchange
-    ".VN": "VND",   # Vietnam HoSE / HNX
-    ".KL": "MYR",   # Bursa Malaysia
-    ".BK": "THB",   # Thailand SET
-    ".HK": "HKD",   # Hong Kong Stock Exchange
-    ".L": "GBP",    # London Stock Exchange
-    ".AX": "AUD",   # ASX Australia
-    ".T": "JPY",    # Tokyo Stock Exchange
-    ".SS": "CNY",   # Shanghai Stock Exchange
-    ".SZ": "CNY",   # Shenzhen Stock Exchange
-    ".NS": "INR",   # NSE India
-    ".BO": "INR",   # BSE India
-    ".JK": "IDR",   # Indonesia IDX
+    ".SI": "SGD",  # Singapore Exchange
+    ".VN": "VND",  # Vietnam HoSE / HNX
+    ".KL": "MYR",  # Bursa Malaysia
+    ".BK": "THB",  # Thailand SET
+    ".HK": "HKD",  # Hong Kong Stock Exchange
+    ".L": "GBP",  # London Stock Exchange
+    ".AX": "AUD",  # ASX Australia
+    ".T": "JPY",  # Tokyo Stock Exchange
+    ".SS": "CNY",  # Shanghai Stock Exchange
+    ".SZ": "CNY",  # Shenzhen Stock Exchange
+    ".NS": "INR",  # NSE India
+    ".BO": "INR",  # BSE India
+    ".JK": "IDR",  # Indonesia IDX
 }
 
 

--- a/neufin-backend/services/calculator.py
+++ b/neufin-backend/services/calculator.py
@@ -970,6 +970,41 @@ def _fetch_prices(symbols: list[str], period: str) -> pd.DataFrame:
 
 
 # ── Portfolio metrics (used by routers/portfolio.py) ──────────────────────────
+# ── Currency detection ────────────────────────────────────────────────────────
+# Maps ticker exchange suffix → ISO 4217 currency code.
+_SUFFIX_CURRENCY: dict[str, str] = {
+    ".SI": "SGD",   # Singapore Exchange
+    ".VN": "VND",   # Vietnam HoSE / HNX
+    ".KL": "MYR",   # Bursa Malaysia
+    ".BK": "THB",   # Thailand SET
+    ".HK": "HKD",   # Hong Kong Stock Exchange
+    ".L": "GBP",    # London Stock Exchange
+    ".AX": "AUD",   # ASX Australia
+    ".T": "JPY",    # Tokyo Stock Exchange
+    ".SS": "CNY",   # Shanghai Stock Exchange
+    ".SZ": "CNY",   # Shenzhen Stock Exchange
+    ".NS": "INR",   # NSE India
+    ".BO": "INR",   # BSE India
+    ".JK": "IDR",   # Indonesia IDX
+}
+
+
+def detect_portfolio_currency(symbols: list[str]) -> str:
+    """
+    Infer the dominant currency from ticker exchange suffixes.
+    Returns the currency of the majority of detected symbols, falling back to USD.
+    """
+    counts: dict[str, int] = {}
+    for sym in symbols:
+        for suffix, curr in _SUFFIX_CURRENCY.items():
+            if sym.upper().endswith(suffix.upper()):
+                counts[curr] = counts.get(curr, 0) + 1
+                break
+    if not counts:
+        return "USD"
+    return max(counts, key=lambda c: counts[c])
+
+
 def calculate_portfolio_metrics(positions: list) -> dict:
     """Calculate diversification, concentration, volatility, and returns."""
     df = pd.DataFrame(positions)
@@ -1061,8 +1096,11 @@ def calculate_portfolio_metrics(positions: list) -> dict:
         positions_out["symbol"].map(price_status).fillna("live")
     )
 
+    base_currency = detect_portfolio_currency(symbols)
+
     result = {
         "total_value": float(total_value),
+        "base_currency": base_currency,
         "hhi": round(float((df["weight"] ** 2).sum()), 4) if total_value > 0 else 0.0,
         "num_positions": len(df),
         "num_priced": len(resolved),

--- a/neufin-web/app/features/page.tsx
+++ b/neufin-web/app/features/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import Image from "next/image";
 
 export const metadata: Metadata = {
   title: "Features — Behavioral Finance Intelligence Platform",
@@ -108,8 +109,8 @@ export default function FeaturesPage() {
         {/* Nav */}
         <nav className="border-b border-shell-border/60 sticky top-0 z-10 bg-shell-deep/90 backdrop-blur-sm">
           <div className="max-w-6xl mx-auto px-6 h-16 flex items-center justify-between">
-            <Link href="/" className="text-xl font-bold text-gradient">
-              NeuFin
+            <Link href="/">
+              <Image src="/logo.png" alt="NeuFin" width={140} height={36} className="h-9 w-auto brightness-0 invert" />
             </Link>
             <div className="flex items-center gap-3">
               <Link
@@ -159,17 +160,17 @@ export default function FeaturesPage() {
 
           {/* Feature grid */}
           <section className="mb-20">
-            <h2 className="text-2xl font-bold text-center mb-10">
+            <h2 className="text-2xl font-bold text-center mb-10 text-shell-fg">
               Platform Capabilities
             </h2>
             <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
               {features.map((f) => (
                 <div key={f.title} className="card space-y-3">
                   <span className="text-3xl">{f.icon}</span>
-                  <h3 className="font-semibold text-lg text-shell-fg">
+                  <h3 className="font-semibold text-lg text-gray-900">
                     {f.title}
                   </h3>
-                  <p className="text-sm text-shell-muted leading-relaxed">
+                  <p className="text-sm text-gray-600 leading-relaxed">
                     {f.description}
                   </p>
                 </div>
@@ -179,10 +180,10 @@ export default function FeaturesPage() {
 
           {/* Bias explainer */}
           <section className="card mb-20">
-            <h2 className="text-xl font-bold mb-4">
+            <h2 className="text-xl font-bold mb-4 text-gray-900">
               The 6 Biases NeuFin Detects
             </h2>
-            <p className="text-shell-muted text-sm mb-6">
+            <p className="text-gray-600 text-sm mb-6">
               Based on research by Daniel Kahneman (Nobel Prize 2002), Richard
               Thaler (Nobel Prize 2017), and NeuFin&apos;s own analysis of
               Singapore SME portfolios.
@@ -214,11 +215,11 @@ export default function FeaturesPage() {
                   "Following institutional flows or trending assets without independent analysis.",
                 ],
               ].map(([name, desc]) => (
-                <div key={name} className="rounded-lg bg-shell-raised/40 p-4">
-                  <p className="font-semibold text-sm text-shell-fg mb-1">
+                <div key={name} className="rounded-lg bg-gray-50 border border-gray-200 p-4">
+                  <p className="font-semibold text-sm text-gray-900 mb-1">
                     {name}
                   </p>
-                  <p className="text-xs text-shell-muted leading-relaxed">
+                  <p className="text-xs text-gray-600 leading-relaxed">
                     {desc}
                   </p>
                 </div>
@@ -228,7 +229,7 @@ export default function FeaturesPage() {
 
           {/* FAQ */}
           <section className="mb-16">
-            <h2 className="text-2xl font-bold text-center mb-10">
+            <h2 className="text-2xl font-bold text-center mb-10 text-shell-fg">
               Frequently Asked Questions
             </h2>
             <div className="space-y-6 max-w-3xl mx-auto">
@@ -245,7 +246,7 @@ export default function FeaturesPage() {
 
           {/* CTA */}
           <section className="text-center rounded-2xl border border-primary/20 bg-primary/5 p-12">
-            <h2 className="text-2xl font-bold mb-3">
+            <h2 className="text-2xl font-bold mb-3 text-shell-fg">
               Ready to Find Your Behavioral Blind Spots?
             </h2>
             <p className="text-shell-muted mb-6">

--- a/neufin-web/app/layout.tsx
+++ b/neufin-web/app/layout.tsx
@@ -1,10 +1,13 @@
 import type { Metadata } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
+import Script from "next/script";
 import "./globals.css";
 import RootProviders from "@/app/components/RootProviders";
 import AuthDebugBoot from "@/app/components/AuthDebugBoot";
 import { AuthDebugPanel } from "@/components/AuthDebugPanel";
 import { ScrollReset } from "@/components/ScrollReset";
+
+const GA_ID = process.env.NEXT_PUBLIC_GA_ID ?? "G-Z2E03GFJP3";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -25,11 +28,11 @@ export const metadata: Metadata = {
   applicationName: "NeuFin",
   icons: {
     icon: [
+      { url: "/favicon.ico", sizes: "any" },
       { url: "/logo-icon.png", sizes: "32x32", type: "image/png" },
-      { url: "/logo-icon.png", sizes: "16x16", type: "image/png" },
     ],
     apple: [{ url: "/logo-icon.png", sizes: "180x180", type: "image/png" }],
-    shortcut: "/logo-icon.png",
+    shortcut: "/favicon.ico",
   },
   title: {
     default: "NeuFin — 7 AI Agents for IC-Grade Portfolio Intelligence",
@@ -174,18 +177,20 @@ export default function RootLayout({
             __html: `if (typeof window !== 'undefined') { if (history.scrollRestoration) { history.scrollRestoration = 'manual'; } window.scrollTo(0, 0); }`,
           }}
         />
-        <script
-          async
-          src="https://www.googletagmanager.com/gtag/js?id=G-Z2E03GFJP3"
-        ></script>
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `window.dataLayer = window.dataLayer || [];
+        {GA_ID && (
+          <>
+            <Script
+              src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
+              strategy="afterInteractive"
+            />
+            <Script id="gtag-init" strategy="afterInteractive">
+              {`window.dataLayer = window.dataLayer || [];
 function gtag(){dataLayer.push(arguments);}
 gtag('js', new Date());
-gtag('config', 'G-Z2E03GFJP3');`,
-          }}
-        />
+gtag('config', '${GA_ID}');`}
+            </Script>
+          </>
+        )}
         {/* next/font serves locally; keep only app-critical origins */}
         <link
           rel="preconnect"

--- a/neufin-web/app/research/[slug]/page.tsx
+++ b/neufin-web/app/research/[slug]/page.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeRaw from "rehype-raw";
+import rehypeSanitize from "rehype-sanitize";
 import { ShareResearchUrlButton } from "@/components/research/ShareResearchUrlButton";
 
 function regimeBadge(regime: string | null | undefined) {
@@ -23,10 +26,10 @@ function regimeBadge(regime: string | null | undefined) {
 function regimeBadgeClass(regime: string | null | undefined) {
   const k = (regime || "").toLowerCase();
   if (k.includes("risk_on") || k === "recovery")
-    return "border-emerald-500/40 bg-emerald-500/15 text-emerald-200";
+    return "border-emerald-300 bg-emerald-100 text-emerald-700";
   if (k.includes("risk_off") || k.includes("recession"))
-    return "border-red-500/40 bg-red-500/15 text-red-200";
-  return "border-slate-500/40 bg-slate-500/15 text-slate-200";
+    return "border-red-300 bg-red-100 text-red-700";
+  return "border-slate-300 bg-slate-100 text-slate-700";
 }
 
 type RelatedNote = {
@@ -169,8 +172,11 @@ export default async function ResearchArticlePage({
             </div>
           </header>
 
-          <div className="prose prose-invert max-w-none prose-p:text-muted-foreground prose-headings:text-foreground">
-            <ReactMarkdown>
+          <div className="prose prose-slate max-w-none prose-p:text-gray-700 prose-headings:text-gray-900 prose-a:text-primary prose-strong:text-gray-900 prose-code:text-gray-800 prose-code:bg-gray-100 prose-pre:bg-gray-900 prose-pre:text-gray-100">
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              rehypePlugins={[rehypeRaw, rehypeSanitize]}
+            >
               {note.content || note.executive_summary}
             </ReactMarkdown>
           </div>

--- a/neufin-web/app/research/page.tsx
+++ b/neufin-web/app/research/page.tsx
@@ -55,10 +55,10 @@ function regimePillLabel(r: string | null | undefined) {
 function regimePillClass(r: string | null | undefined) {
   const k = (r || "").toLowerCase();
   if (k.includes("risk_on") || k === "recovery")
-    return "bg-emerald-500/15 text-emerald-300 border-emerald-500/30";
+    return "bg-emerald-100 text-emerald-700 border-emerald-300";
   if (k.includes("risk_off") || k.includes("recession"))
-    return "bg-red-500/15 text-red-300 border-red-500/30";
-  return "bg-slate-500/15 text-slate-200 border-slate-500/30";
+    return "bg-red-100 text-red-700 border-red-300";
+  return "bg-slate-100 text-slate-700 border-slate-300";
 }
 
 async function fetchNotes(): Promise<ResearchNoteRow[]> {

--- a/neufin-web/app/terms-and-conditions/page.tsx
+++ b/neufin-web/app/terms-and-conditions/page.tsx
@@ -99,7 +99,7 @@ export default function TermsPage() {
               </p>
             </div>
 
-            <div className="prose prose-invert max-w-none space-y-10 text-[15px] leading-relaxed text-muted-foreground">
+            <div className="prose prose-slate max-w-none space-y-10 text-[15px] leading-relaxed text-gray-700">
               <section id="acceptance">
                 <h2 className="mb-3 text-xl font-semibold text-foreground">
                   1. Acceptance of Terms

--- a/neufin-web/app/upload/page.tsx
+++ b/neufin-web/app/upload/page.tsx
@@ -172,11 +172,24 @@ export default function UploadPage() {
       <main className="flex-1 flex items-center justify-center p-6">
         <div className="w-full max-w-xl">
           <h1 className="text-3xl font-bold mb-2">Upload your portfolio</h1>
-          <p className="text-shell-muted mb-8">
+          <p className="text-shell-muted mb-4">
             CSV with columns: <code className="text-primary">symbol</code>,{" "}
             <code className="text-primary">shares</code>, and optional{" "}
             <code className="text-primary">cost_basis</code>
           </p>
+          <div className="mb-6 rounded-lg border border-shell-border/60 bg-shell-raised/30 px-4 py-3 text-xs text-shell-muted">
+            <p className="font-semibold text-shell-fg mb-1">SEA &amp; international markets supported</p>
+            <p>Use exchange suffixes for non-US tickers — the system auto-detects currency from your symbols:</p>
+            <ul className="mt-1 grid grid-cols-2 gap-x-4 gap-y-0.5 font-mono text-primary">
+              <li>.SI → SGD (Singapore)</li>
+              <li>.VN → VND (Vietnam)</li>
+              <li>.KL → MYR (Malaysia)</li>
+              <li>.BK → THB (Thailand)</li>
+              <li>.HK → HKD (Hong Kong)</li>
+              <li>.L → GBP (London)</li>
+            </ul>
+            <p className="mt-1.5">Example: <span className="text-primary font-mono">VCB.VN</span>, <span className="text-primary font-mono">D05.SI</span>, <span className="text-primary font-mono">1155.KL</span></p>
+          </div>
 
           {/* Drop zone */}
           <div

--- a/neufin-web/components/AppHeader.tsx
+++ b/neufin-web/components/AppHeader.tsx
@@ -99,11 +99,14 @@ export default function AppHeader() {
   return (
     <header className="sticky top-0 z-30 border-b border-border bg-white/95 backdrop-blur-sm">
       <div className="mx-auto flex h-14 max-w-screen-xl items-center justify-between gap-4 px-4">
-        <Link
-          href="/dashboard"
-          className="shrink-0 text-xl font-semibold tracking-tight text-navy"
-        >
-          NeuFin
+        <Link href="/dashboard" className="shrink-0">
+          <Image
+            src="/logo.png"
+            alt="NeuFin"
+            width={140}
+            height={36}
+            className="h-9 w-auto"
+          />
         </Link>
 
         <nav className="hidden items-center gap-1 md:flex">

--- a/neufin-web/components/BrandLogo.tsx
+++ b/neufin-web/components/BrandLogo.tsx
@@ -1,0 +1,34 @@
+import Image from "next/image";
+import Link from "next/link";
+
+type Variant = "nav" | "sidebar" | "footer" | "footer-dark";
+
+const SIZE: Record<Variant, { width: number; height: number; cls: string }> = {
+  nav:         { width: 160, height: 40, cls: "h-10 w-auto" },
+  sidebar:     { width: 140, height: 36, cls: "h-9 w-auto" },
+  footer:      { width: 140, height: 36, cls: "h-9 w-auto" },
+  "footer-dark": { width: 140, height: 36, cls: "h-9 w-auto brightness-0 invert" },
+};
+
+interface BrandLogoProps {
+  variant?: Variant;
+  href?: string;
+  className?: string;
+}
+
+export function BrandLogo({ variant = "nav", href = "/", className }: BrandLogoProps) {
+  const { width, height, cls } = SIZE[variant];
+
+  const img = (
+    <Image
+      src="/logo.png"
+      alt="NeuFin"
+      width={width}
+      height={height}
+      className={`${cls} ${className ?? ""}`.trim()}
+      priority={variant === "nav"}
+    />
+  );
+
+  return href ? <Link href={href} className="shrink-0">{img}</Link> : img;
+}

--- a/neufin-web/components/CommandBar.tsx
+++ b/neufin-web/components/CommandBar.tsx
@@ -119,9 +119,9 @@ export function CommandBar({
           <Image
             src="/logo.png"
             alt="NeuFin"
-            width={120}
+            width={140}
             height={40}
-            className="hidden h-8 w-auto md:block"
+            className="hidden h-9 w-auto sm:block"
           />
           <span
             className="hidden h-4 w-px shrink-0 bg-border sm:block"

--- a/neufin-web/components/DashboardSidebar.tsx
+++ b/neufin-web/components/DashboardSidebar.tsx
@@ -235,20 +235,13 @@ export default function DashboardSidebar({
       aria-label={embedded ? undefined : "Main navigation"}
     >
       {!embedded && (
-        <div className="flex h-16 shrink-0 items-center justify-center gap-3 border-b border-[#F1F5F9] bg-gradient-to-r from-white to-[#F8FAFC] px-5">
-          <Image
-            src="/logo-icon.png"
-            alt=""
-            width={28}
-            height={28}
-            className="h-7 w-7 shrink-0 rounded-sm"
-          />
+        <div className="flex h-16 shrink-0 items-center justify-center border-b border-[#F1F5F9] bg-gradient-to-r from-white to-[#F8FAFC] px-5">
           <Image
             src="/logo.png"
             alt="NeuFin"
-            width={100}
-            height={28}
-            className="h-7 w-auto max-w-[140px] shrink-0 object-contain object-left"
+            width={140}
+            height={36}
+            className="h-9 w-auto shrink-0 object-contain object-left"
           />
         </div>
       )}

--- a/neufin-web/components/auth/AuthScreen.tsx
+++ b/neufin-web/components/auth/AuthScreen.tsx
@@ -157,14 +157,28 @@ function AuthScreenInner({ initialMode }: { initialMode: "login" | "signup" }) {
           email,
           password,
         });
-        if (err) throw err;
+        if (err) {
+          const msg = err.message?.toLowerCase() ?? "";
+          if (msg.includes("email not confirmed") || msg.includes("email_not_confirmed")) {
+            throw new Error(
+              "Please confirm your email before signing in. Check your inbox for the confirmation link.",
+            );
+          }
+          if (msg.includes("invalid login credentials") || msg.includes("invalid_credentials")) {
+            throw new Error("Incorrect email or password. Please try again.");
+          }
+          if (msg.includes("too many requests") || msg.includes("rate_limit")) {
+            throw new Error("Too many sign-in attempts. Please wait a moment and try again.");
+          }
+          throw err;
+        }
         capture("user_logged_in", { method: "email" });
         if (data.session?.access_token)
           await claimPendingRecord(data.session.access_token);
         router.replace(next);
       }
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : "Authentication failed");
+      setError(e instanceof Error ? e.message : "Authentication failed. Please try again.");
     } finally {
       setLoading(false);
     }

--- a/neufin-web/components/dashboard/DashboardClient.tsx
+++ b/neufin-web/components/dashboard/DashboardClient.tsx
@@ -59,6 +59,7 @@ type MetricPosition = {
 
 type PortfolioMetrics = {
   total_value: number;
+  base_currency?: string;
   dna_score: number;
   weighted_beta: number;
   annualized_volatility?: number;
@@ -94,11 +95,14 @@ function maxDrawdownPct(points: { value: number }[]): number | null {
   return maxDD * 100;
 }
 
-const fmtMoney = new Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-  maximumFractionDigits: 0,
-});
+function makeFmtMoney(currency = "USD") {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+    maximumFractionDigits: 0,
+  });
+}
+const fmtMoneyUSD = makeFmtMoney("USD");
 
 const NAV = [
   { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
@@ -121,6 +125,9 @@ export default function DashboardClient() {
   const [portfolios, setPortfolios] = useState<PortfolioRow[] | null>(null);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [metrics, setMetrics] = useState<PortfolioMetrics | null>(null);
+  const fmtMoney = metrics?.base_currency
+    ? makeFmtMoney(metrics.base_currency)
+    : fmtMoneyUSD;
   const [history, setHistory] = useState<{ time: string; value: number }[]>([]);
   const [notes, setNotes] = useState<ResearchNote[]>([]);
   const [loadMain, setLoadMain] = useState(true);

--- a/neufin-web/components/dashboard/DashboardCockpitClient.tsx
+++ b/neufin-web/components/dashboard/DashboardCockpitClient.tsx
@@ -15,7 +15,7 @@ import {
 import { KPICard } from "@/components/ui/KPICard";
 import ResearchFeedClient from "@/components/dashboard/ResearchFeedClient";
 import { usePortfolioDNA } from "@/hooks/usePortfolioDNA";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 export type CockpitNote = {
   id: string;
@@ -105,9 +105,24 @@ export default function DashboardCockpitClient({
   researchNotes: CockpitNote[];
 }) {
   const { loading: dnaLoading, score, hasPortfolio } = usePortfolioDNA();
-  const [marketTab, setMarketTab] = useState<
-    "S&P 500" | "NASDAQ" | "STI" | "FTSE"
-  >("S&P 500");
+  type IndexLabel = "S&P 500" | "NASDAQ" | "FTSE 100" | "STI" | "VNIndex" | "KLCI" | "SET" | "HSI";
+  const ALL_TABS: IndexLabel[] = ["S&P 500", "NASDAQ", "FTSE 100", "STI", "VNIndex", "KLCI", "SET", "HSI"];
+  const [marketTab, setMarketTab] = useState<IndexLabel>("S&P 500");
+  const [indexQuotes, setIndexQuotes] = useState<Record<string, { price: number | null; change_pct: number | null; currency: string; status: string }>>({});
+
+  useEffect(() => {
+    fetch("/api/market/indices")
+      .then((r) => r.ok ? r.json() : null)
+      .then((data) => {
+        if (!data?.indices) return;
+        const map: typeof indexQuotes = {};
+        for (const q of data.indices as Array<{ label: string; price: number | null; change_pct: number | null; currency: string; status: string }>) {
+          map[q.label] = { price: q.price, change_pct: q.change_pct, currency: q.currency, status: q.status };
+        }
+        setIndexQuotes(map);
+      })
+      .catch(() => {});
+  }, []);
 
   const notes = researchNotes ?? [];
 
@@ -243,8 +258,8 @@ export default function DashboardCockpitClient({
                 Index tabs (fallback mode)
               </span>
             </div>
-            <div className="mb-4 flex flex-wrap gap-2">
-              {(["S&P 500", "NASDAQ", "STI", "FTSE"] as const).map((tab) => {
+            <div className="mb-4 flex flex-wrap gap-1.5">
+              {ALL_TABS.map((tab) => {
                 const active = tab === marketTab;
                 return (
                   <button
@@ -252,32 +267,52 @@ export default function DashboardCockpitClient({
                     type="button"
                     onClick={() => setMarketTab(tab)}
                     className={[
-                      "rounded px-2 py-1 font-mono text-sm",
+                      "rounded px-2 py-1 font-mono text-xs",
                       active
-                        ? "bg-primary/15 text-primary"
+                        ? "bg-primary/15 text-primary font-semibold"
                         : "text-muted-foreground hover:text-foreground",
                     ].join(" ")}
-                    title="Index endpoint unavailable, showing regime-confidence fallback"
                   >
                     {tab}
                   </button>
                 );
               })}
             </div>
-            <div className="flex items-center justify-between gap-4">
-              <div className="min-w-0">
-                <p className="text-sm font-semibold text-foreground">
-                  {regimeLabel}
-                </p>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  {marketTab} data endpoint unavailable — showing live regime
-                  confidence fallback
-                </p>
-              </div>
-              <p className="shrink-0 font-mono text-sm tabular-nums text-foreground">
-                {Math.round(confidence * 100)}%
-              </p>
-            </div>
+            {(() => {
+              const q = indexQuotes[marketTab];
+              if (q?.price != null) {
+                const up = (q.change_pct ?? 0) >= 0;
+                return (
+                  <div className="flex items-center justify-between gap-4">
+                    <div className="min-w-0">
+                      <p className="text-sm font-semibold text-foreground">{marketTab}</p>
+                      <p className="mt-0.5 font-mono text-xl font-bold tabular-nums text-foreground">
+                        {q.price.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+                        <span className="ml-1 text-xs font-normal text-muted-foreground">{q.currency}</span>
+                      </p>
+                    </div>
+                    {q.change_pct != null && (
+                      <span className={`shrink-0 rounded-full px-2 py-0.5 font-mono text-sm font-semibold ${up ? "bg-emerald-100 text-emerald-700" : "bg-red-100 text-red-700"}`}>
+                        {up ? "+" : ""}{q.change_pct.toFixed(2)}%
+                      </span>
+                    )}
+                  </div>
+                );
+              }
+              return (
+                <div className="flex items-center justify-between gap-4">
+                  <div className="min-w-0">
+                    <p className="text-sm font-semibold text-foreground">{regimeLabel}</p>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      {marketTab} — live regime confidence ({Math.round(confidence * 100)}%)
+                    </p>
+                  </div>
+                  <p className="shrink-0 font-mono text-sm tabular-nums text-foreground">
+                    {Math.round(confidence * 100)}%
+                  </p>
+                </div>
+              );
+            })()}
             <div className="mt-3 h-2 overflow-hidden rounded-full bg-surface-2">
               <div
                 className={`h-full rounded-full ${

--- a/neufin-web/components/dashboard/DashboardShell.tsx
+++ b/neufin-web/components/dashboard/DashboardShell.tsx
@@ -9,8 +9,8 @@ import { CommandBar } from "@/components/CommandBar";
 import { CheckoutSessionSuccessFeedback } from "@/components/dashboard/CheckoutSessionSuccessFeedback";
 import { TrialStatusBanner } from "@/components/dashboard/TrialStatusBanner";
 import { MarketDeskRail } from "@/components/dashboard/MarketDeskRail";
-import Image from "next/image";
 import { usePathname } from "next/navigation";
+import { BrandLogo } from "@/components/BrandLogo";
 
 const RAIL_STORAGE_KEY = "neufin:dashboard:marketdesk-open";
 
@@ -82,21 +82,8 @@ export function DashboardShell({
           />
           <aside className="relative z-10 flex h-full w-72 max-w-[min(18rem,88vw)] flex-col bg-white shadow-2xl">
             <div className="flex h-16 flex-shrink-0 items-center justify-between border-b border-[#E2E8F0] px-5">
-              <div className="flex items-center gap-2">
-                <Image
-                  src="/logo-icon.png"
-                  alt=""
-                  width={32}
-                  height={32}
-                  className="h-8 w-8 rounded-sm"
-                />
-                <Image
-                  src="/logo.png"
-                  alt="NeuFin"
-                  width={120}
-                  height={32}
-                  className="h-8 w-auto"
-                />
+              <div className="flex items-center">
+                <BrandLogo variant="sidebar" href="/dashboard" />
               </div>
               <button
                 type="button"
@@ -124,21 +111,8 @@ export function DashboardShell({
           >
             <Menu className="h-5 w-5" strokeWidth={1.5} />
           </button>
-          <div className="flex items-center gap-2">
-            <Image
-              src="/logo-icon.png"
-              alt=""
-              width={32}
-              height={32}
-              className="h-8 w-8 rounded-sm"
-            />
-            <Image
-              src="/logo.png"
-              alt="NeuFin"
-              width={120}
-              height={32}
-              className="h-8 w-auto"
-            />
+          <div className="flex items-center">
+            <BrandLogo variant="sidebar" href="/dashboard" />
           </div>
         </header>
         <CommandBar

--- a/neufin-web/components/landing/Footer.tsx
+++ b/neufin-web/components/landing/Footer.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import Image from "next/image";
 
 const FOOTER_LINKS = {
   Product: [
@@ -30,7 +31,13 @@ export default function Footer() {
       <div className="mx-auto max-w-7xl px-6">
         <div className="grid gap-10 md:grid-cols-2 lg:grid-cols-5">
           <div className="lg:col-span-2">
-            <p className="text-lg font-semibold text-foreground">NeuFin</p>
+            <Image
+              src="/logo.png"
+              alt="NeuFin"
+              width={140}
+              height={36}
+              className="h-9 w-auto"
+            />
             <p className="mt-3 max-w-md text-sm leading-relaxed text-muted-foreground">
               IC-grade portfolio intelligence in about a minute. Built for
               advisors, wealth platforms, and teams who need committee-ready

--- a/neufin-web/components/landing/HomeLandingPage.tsx
+++ b/neufin-web/components/landing/HomeLandingPage.tsx
@@ -220,9 +220,9 @@ export default function HomeLandingPage({
             <Image
               src="/logo.png"
               alt="NeuFin"
-              width={120}
-              height={32}
-              className="h-8 w-auto"
+              width={160}
+              height={40}
+              className="h-10 w-auto"
               priority
             />
           </Link>
@@ -914,14 +914,14 @@ export default function HomeLandingPage({
               <h2 className="mb-2 text-[30px] font-bold text-white">
                 Real-time regime monitoring
               </h2>
-              <p className="text-[14px] text-slate-400">
+              <p className="text-[14px] text-slate-300">
                 Our agents monitor 40+ macro signals continuously
               </p>
             </div>
 
             <div className="grid gap-5 lg:grid-cols-2">
               <div className="rounded-2xl border border-white/10 bg-white/[0.06] p-5">
-                <p className="text-sm font-semibold uppercase tracking-wide text-slate-400">
+                <p className="text-sm font-semibold uppercase tracking-wide text-slate-300">
                   Current regime
                 </p>
                 {regimeLabel ? (
@@ -948,7 +948,7 @@ export default function HomeLandingPage({
               </div>
 
               <div className="rounded-2xl border border-white/10 bg-white/[0.06] p-5">
-                <p className="text-sm font-semibold uppercase tracking-wide text-slate-400">
+                <p className="text-sm font-semibold uppercase tracking-wide text-slate-300">
                   Latest research
                 </p>
                 {teaser.length > 0 ? (
@@ -960,7 +960,7 @@ export default function HomeLandingPage({
                           className="text-[15px] font-medium text-white transition-colors hover:text-[#1EB8CC]"
                         >
                           {note.title ?? "Research note"}
-                          <span className="ml-2 text-slate-400">→</span>
+                          <span className="ml-2 text-slate-300">→</span>
                         </Link>
                       </li>
                     ))}
@@ -1032,9 +1032,9 @@ export default function HomeLandingPage({
               <Image
                 src="/logo.png"
                 alt="NeuFin"
-                width={120}
-                height={32}
-                className="mb-5 h-8 w-auto brightness-0 invert"
+                width={160}
+                height={40}
+                className="mb-5 h-10 w-auto brightness-0 invert"
               />
               <p className="mb-4 text-sm leading-[1.7] text-slate-400">
                 Institutional-grade portfolio intelligence for advisors, IFAs,
@@ -1080,7 +1080,7 @@ export default function HomeLandingPage({
               ] as const
             ).map((col) => (
               <div key={col.heading}>
-                <p className="mb-5 text-xs font-bold uppercase tracking-widest text-slate-400">
+                <p className="mb-5 text-xs font-bold uppercase tracking-widest text-slate-300">
                   {col.heading}
                 </p>
                 <div className="space-y-3">
@@ -1088,7 +1088,7 @@ export default function HomeLandingPage({
                     <Link
                       key={l}
                       href={href}
-                      className="block text-sm text-slate-400 transition-colors hover:text-white"
+                      className="block text-sm text-slate-300 transition-colors hover:text-white"
                     >
                       {l}
                     </Link>

--- a/neufin-web/components/pricing/PricingPageClient.tsx
+++ b/neufin-web/components/pricing/PricingPageClient.tsx
@@ -110,8 +110,8 @@ export default function PricingPageClient() {
     <div className="flex min-h-screen flex-col bg-[var(--bg-app)]">
       <nav className="sticky top-0 z-10 border-b border-[var(--border)] bg-white/95 backdrop-blur-md">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 h-14 flex items-center justify-between">
-          <Link href="/" className="font-sans text-xl text-primary">
-            NeuFin
+          <Link href="/" className="shrink-0">
+            <Image src="/logo.png" alt="NeuFin" width={140} height={36} className="h-9 w-auto" />
           </Link>
           <div className="flex gap-2">
             <Link href="/upload" className="btn-secondary px-3 py-2 text-sm">
@@ -193,8 +193,8 @@ export default function PricingPageClient() {
           </GlassCard>
 
           {/* Advisor */}
-          <GlassCard className="relative flex flex-col rounded-xl border-2 border-primary bg-white p-7 shadow-[var(--shadow-sm)]">
-            <span className="absolute -top-3 right-4 rounded-full bg-primary px-2 py-1 text-xs font-bold uppercase tracking-wide text-white">
+          <GlassCard className="relative flex flex-col rounded-xl border-2 border-primary bg-white p-7 pt-9 shadow-[var(--shadow-sm)]">
+            <span className="absolute -top-3.5 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-full bg-primary px-3 py-1 text-xs font-bold uppercase tracking-wide text-white shadow-md">
               Most Popular
             </span>
             <p className="mb-2 text-base font-bold uppercase tracking-wide text-navy">
@@ -292,9 +292,9 @@ export default function PricingPageClient() {
           <Image
             src="/logo.png"
             alt="NeuFin"
-            width={90}
-            height={26}
-            className="mb-3 h-6 w-auto opacity-80"
+            width={140}
+            height={36}
+            className="mb-3 h-9 w-auto"
           />
           <span>NeuFin © {new Date().getFullYear()}</span>
         </div>

--- a/neufin-web/package-lock.json
+++ b/neufin-web/package-lock.json
@@ -28,6 +28,9 @@
         "react-hot-toast": "^2.6.0",
         "react-markdown": "^10.1.0",
         "recharts": "^2.12.7",
+        "rehype-raw": "^7.0.0",
+        "rehype-sanitize": "^6.0.0",
+        "remark-gfm": "^4.0.1",
         "resend": "^6.10.0",
         "stripe": "^21.0.1"
       },
@@ -6532,6 +6535,18 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-abstract": {
       "version": "1.24.1",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
@@ -8114,6 +8129,79 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-raw": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "hast-util-to-parse5": "^8.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "parse5": "^7.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-sanitize": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "unist-util-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -8141,6 +8229,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+      "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -8148,6 +8255,23 @@
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -8168,6 +8292,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/http-link-header": {
@@ -10107,6 +10241,16 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/marky": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
@@ -10122,6 +10266,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mdast-util-from-markdown": {
@@ -10142,6 +10314,107 @@
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -10367,6 +10640,127 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -11421,6 +11815,18 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -12404,6 +12810,53 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/rehype-raw": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-raw": "^9.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-sanitize": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
@@ -12431,6 +12884,21 @@
         "mdast-util-to-hast": "^13.0.0",
         "unified": "^11.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -14282,6 +14750,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/vfile-message": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
@@ -14338,6 +14820,16 @@
       "integrity": "sha512-aHlGO8NhNf19aQH5yWd6gFMEWZZh0W91bRMBlNLTaEASF0Ko1Rm4KnY/9rV69lYd9LyQTaJQBVae4PtDxfFJdg==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/web-vitals": {
       "version": "5.1.0",

--- a/neufin-web/package.json
+++ b/neufin-web/package.json
@@ -31,6 +31,9 @@
     "react-hot-toast": "^2.6.0",
     "react-markdown": "^10.1.0",
     "recharts": "^2.12.7",
+    "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
+    "remark-gfm": "^4.0.1",
     "resend": "^6.10.0",
     "stripe": "^21.0.1"
   },


### PR DESCRIPTION
## Summary

- **Logo & branding**: Created `BrandLogo` component; removed duplicate icon+wordmark from sidebar, mobile drawer, and mobile header; replaced all text "NeuFin" instances with the correct logo image across AppHeader, Footer, HomeLandingPage, PricingPageClient, and features page nav; standardised heights (nav 40px, sidebar/footer 36px); fixed favicon to use `/favicon.ico`
- **Contrast**: Fixed white-on-white text (`text-shell-fg` on white `.card` backgrounds) in features page; fixed dark-theme regime pills on light backgrounds in research pages; fixed `prose-invert` on light bg in terms-and-conditions and research article; bumped dark-footer `slate-400` links to `slate-300`
- **Pricing badge**: "Most Popular" badge centred with `left-1/2 -translate-x-1/2`, card padded, `shadow-md` added
- **Research article rendering**: Added `remark-gfm`, `rehype-raw`, `rehype-sanitize` to fix HTML rendering errors in AI-generated markdown content
- **Auth 400 errors**: Differentiate Supabase error codes — unconfirmed email, invalid credentials, rate limit each surface actionable user messages
- **GTM**: Gated behind `NEXT_PUBLIC_GA_ID` env var using `next/script strategy="afterInteractive"` to avoid render blocking
- **SEA markets (P3)**: New `/api/market/indices` backend endpoint via yfinance serving S&P 500, NASDAQ, FTSE 100, STI, VNIndex, KLCI, SET, HSI with 5-min cache; `yfinance>=0.2.40` added to production `requirements.txt`; dashboard market overview expanded to 8 tabs with live price + % change display
- **Currency normalization (P3)**: `detect_portfolio_currency()` infers ISO 4217 currency from exchange suffix (`.SI`→SGD, `.VN`→VND, `.KL`→MYR, `.BK`→THB, `.HK`→HKD, `.L`→GBP); `base_currency` returned in portfolio metrics API; `DashboardClient` formats monetary values in the correct currency; upload page now shows exchange suffix reference for SEA users

## Test plan

- [ ] Dashboard: verify single logo appears in sidebar (not duplicated), logo visible in mobile drawer header
- [ ] Landing nav, Footer, Pricing page nav: logo image renders at correct size
- [ ] features/page.tsx: "Platform Capabilities" card text readable (dark on white), "6 Biases" heading visible
- [ ] Research listing: regime pills (Risk-On / Risk-Off / Neutral) readable on light card backgrounds
- [ ] Research article page: markdown content renders correctly without raw HTML tags
- [ ] Terms page: body text readable (not white on white)
- [ ] Pricing page: "Most Popular" badge centred and fully visible on the Advisor card
- [ ] Auth: sign-in with wrong password shows "Incorrect email or password"; unconfirmed account shows confirmation prompt
- [ ] Dashboard market overview: all 8 tabs (incl. VNIndex, KLCI, SET, HSI) appear and show live data when backend is reachable
- [ ] Upload a portfolio with `.SI` or `.VN` tickers — dashboard displays SGD or VND currency symbol
- [ ] `NEXT_PUBLIC_GA_ID` unset → no GTM script injected; set → loads after interactive

🤖 Generated with [Claude Code](https://claude.com/claude-code)