### PR TITLE
feat(brand+research): logo upgrade + research content normalization

### DIFF
--- a/neufin-backend/routers/research.py
+++ b/neufin-backend/routers/research.py
@@ -36,6 +36,76 @@ logger = structlog.get_logger("neufin.research")
 router = APIRouter(prefix="/api/research", tags=["research"])
 
 
+def _dict_to_markdown(data: dict) -> str:
+    """Convert a structured research note dict to clean markdown prose.
+
+    Handles the common LLM-output schema:
+      thesis / executive_summary, key_findings, sector_impacts,
+      portfolio_implications, risks, conclusion, recommended_action.
+    Falls back to JSON pretty-print only as a last resort.
+    """
+    lines: list[str] = []
+
+    def _add_section(heading: str, value: object) -> None:
+        if not value:
+            return
+        lines.append(f"## {heading}\n")
+        if isinstance(value, str):
+            lines.append(value.strip())
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, dict):
+                    # Flatten common dict shapes
+                    parts = []
+                    for k in (
+                        "finding",
+                        "implication",
+                        "sector",
+                        "impact",
+                        "text",
+                        "description",
+                    ):
+                        if item.get(k):
+                            parts.append(str(item[k]).strip())
+                    support = item.get("data_support") or item.get("evidence") or ""
+                    bullet = " — ".join(parts) if parts else str(item)
+                    lines.append(f"- {bullet}")
+                    if support:
+                        lines.append(f"  *{support}*")
+                else:
+                    lines.append(f"- {item}")
+        else:
+            lines.append(str(value))
+        lines.append("")
+
+    known_keys_handled = set()
+
+    # Ordered presentation
+    for field, label in (
+        ("thesis", "Thesis"),
+        ("executive_summary", "Executive Summary"),
+        ("key_findings", "Key Findings"),
+        ("sector_impacts", "Sector Impacts"),
+        ("portfolio_implications", "Portfolio Implications"),
+        ("risks", "Risks"),
+        ("conclusion", "Conclusion"),
+        ("recommended_action", "Recommended Action"),
+    ):
+        val = data.get(field)
+        if val:
+            _add_section(label, val)
+            known_keys_handled.add(field)
+
+    # Catch-all for any remaining string/list fields not yet handled
+    for k, v in data.items():
+        if k in known_keys_handled or k in ("title", "id", "slug", "generated_at"):
+            continue
+        if isinstance(v, str | list) and v:
+            _add_section(k.replace("_", " ").title(), v)
+
+    return "\n".join(lines).strip() if lines else json.dumps(data, indent=2)
+
+
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 
@@ -762,8 +832,18 @@ async def get_blog_note(slug: str):
     note_slug = str(note.get("slug") or "").strip() or slugify(title)
     content = note.get("content") or note.get("body") or note.get("full_content") or ""
     if isinstance(content, dict):
-        content = json.dumps(content, indent=2)
-    elif not isinstance(content, str):
+        content = _dict_to_markdown(content)
+    elif isinstance(content, str):
+        # Content might be a JSON-encoded dict stored as a string
+        stripped = content.strip()
+        if stripped.startswith("{") and stripped.endswith("}"):
+            try:
+                parsed = json.loads(stripped)
+                if isinstance(parsed, dict):
+                    content = _dict_to_markdown(parsed)
+            except (json.JSONDecodeError, ValueError):
+                pass
+    else:
         content = str(content)
     tickers = note.get("asset_tickers") or note.get("affected_tickers") or []
     if not isinstance(tickers, list):

--- a/neufin-web/app/features/page.tsx
+++ b/neufin-web/app/features/page.tsx
@@ -109,8 +109,8 @@ export default function FeaturesPage() {
         {/* Nav */}
         <nav className="border-b border-shell-border/60 sticky top-0 z-10 bg-shell-deep/90 backdrop-blur-sm">
           <div className="max-w-6xl mx-auto px-6 h-16 flex items-center justify-between">
-            <Link href="/">
-              <Image src="/logo.png" alt="NeuFin" width={140} height={36} className="h-9 w-auto brightness-0 invert" />
+            <Link href="/" className="shrink-0 flex-none">
+              <Image src="/logo.png" alt="NeuFin" width={160} height={40} className="h-12 w-auto brightness-0 invert" priority />
             </Link>
             <div className="flex items-center gap-3">
               <Link

--- a/neufin-web/app/research/[slug]/page.tsx
+++ b/neufin-web/app/research/[slug]/page.tsx
@@ -5,6 +5,7 @@ import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize from "rehype-sanitize";
 import { ShareResearchUrlButton } from "@/components/research/ShareResearchUrlButton";
+import { normalizeResearchContent } from "@/lib/research-normalizer";
 
 function regimeBadge(regime: string | null | undefined) {
   if (!regime) return "Neutral";
@@ -120,11 +121,17 @@ export default async function ResearchArticlePage({
     );
   }
 
-  const keyInsights = note.executive_summary
-    .split(".")
-    .map((s) => s.trim())
-    .filter(Boolean)
-    .slice(0, 3);
+  const report = normalizeResearchContent(note.content, note.executive_summary);
+  const s = report.structured;
+
+  const keyInsights =
+    s?.key_findings && s.key_findings.length > 0
+      ? s.key_findings.slice(0, 3).map((f) => f.finding)
+      : note.executive_summary
+          .split(".")
+          .map((x) => x.trim())
+          .filter(Boolean)
+          .slice(0, 3);
 
   return (
     <div className="min-h-screen bg-background text-foreground">
@@ -172,14 +179,153 @@ export default async function ResearchArticlePage({
             </div>
           </header>
 
-          <div className="prose prose-slate max-w-none prose-p:text-gray-700 prose-headings:text-gray-900 prose-a:text-primary prose-strong:text-gray-900 prose-code:text-gray-800 prose-code:bg-gray-100 prose-pre:bg-gray-900 prose-pre:text-gray-100">
-            <ReactMarkdown
-              remarkPlugins={[remarkGfm]}
-              rehypePlugins={[rehypeRaw, rehypeSanitize]}
-            >
-              {note.content || note.executive_summary}
-            </ReactMarkdown>
-          </div>
+          {/* Structured sections (when content was a JSON dict) */}
+          {s && (
+            <div className="mb-8 space-y-6">
+              {s.key_findings && s.key_findings.length > 0 && (
+                <section className="rounded-xl border border-border bg-surface p-5">
+                  <h2 className="mb-3 text-xs font-mono uppercase tracking-widest text-muted-foreground">
+                    Key Findings
+                  </h2>
+                  <ul className="space-y-3">
+                    {s.key_findings.map((f, i) => (
+                      <li key={i} className="flex gap-3">
+                        <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/10 font-mono text-xs font-semibold text-primary">
+                          {i + 1}
+                        </span>
+                        <div>
+                          <p className="text-sm font-medium text-foreground">
+                            {f.finding}
+                          </p>
+                          {f.data_support && (
+                            <p className="mt-0.5 text-sm text-muted-foreground">
+                              {f.data_support}
+                            </p>
+                          )}
+                          {f.implication && (
+                            <p className="mt-0.5 text-sm text-primary/80">
+                              → {f.implication}
+                            </p>
+                          )}
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              )}
+
+              {s.sector_impacts && s.sector_impacts.length > 0 && (
+                <section className="rounded-xl border border-border bg-surface p-5">
+                  <h2 className="mb-3 text-xs font-mono uppercase tracking-widest text-muted-foreground">
+                    Sector Impacts
+                  </h2>
+                  <div className="grid gap-2 sm:grid-cols-2">
+                    {s.sector_impacts.map((si, i) => {
+                      const dir = (si.direction ?? "").toLowerCase();
+                      const isPositive = dir.includes("positiv") || dir.includes("up") || dir === "bullish";
+                      const isNegative = dir.includes("negativ") || dir.includes("down") || dir === "bearish";
+                      return (
+                        <div
+                          key={i}
+                          className="flex items-start gap-2 rounded-lg border border-border/60 bg-surface-2 p-3"
+                        >
+                          <span
+                            className={`mt-0.5 h-2 w-2 shrink-0 rounded-full ${
+                              isPositive
+                                ? "bg-emerald-500"
+                                : isNegative
+                                  ? "bg-red-500"
+                                  : "bg-amber-400"
+                            }`}
+                          />
+                          <div>
+                            <p className="text-sm font-medium text-foreground">
+                              {si.sector}
+                            </p>
+                            <p className="text-sm text-muted-foreground">
+                              {si.impact}
+                            </p>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </section>
+              )}
+
+              {s.portfolio_implications && s.portfolio_implications.length > 0 && (
+                <section className="rounded-xl border border-primary/20 bg-primary/5 p-5">
+                  <h2 className="mb-3 text-xs font-mono uppercase tracking-widest text-primary/70">
+                    Portfolio Implications
+                  </h2>
+                  <ul className="space-y-1.5">
+                    {s.portfolio_implications.map((imp, i) => (
+                      <li key={i} className="flex gap-2 text-sm text-foreground">
+                        <span className="shrink-0 text-primary">→</span>
+                        {imp}
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              )}
+
+              {s.risks && s.risks.length > 0 && (
+                <section className="rounded-xl border border-amber-200 bg-amber-50 p-5">
+                  <h2 className="mb-3 text-xs font-mono uppercase tracking-widest text-amber-700">
+                    Risk Factors
+                  </h2>
+                  <ul className="space-y-1.5">
+                    {s.risks.map((r, i) => (
+                      <li key={i} className="flex gap-2 text-sm text-amber-900">
+                        <span className="shrink-0">⚠</span>
+                        {r}
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              )}
+
+              {(s.conclusion || s.recommended_action) && (
+                <section className="rounded-xl border border-border bg-surface p-5">
+                  <h2 className="mb-3 text-xs font-mono uppercase tracking-widest text-muted-foreground">
+                    Conclusion
+                  </h2>
+                  <p className="text-sm leading-relaxed text-foreground">
+                    {s.conclusion ?? s.recommended_action}
+                  </p>
+                </section>
+              )}
+            </div>
+          )}
+
+          {/* Full markdown content (prose path) */}
+          {!s && (
+            <div className="prose prose-slate max-w-none prose-p:text-gray-700 prose-headings:text-gray-900 prose-a:text-primary prose-strong:text-gray-900 prose-code:text-gray-800 prose-code:bg-gray-100 prose-pre:bg-gray-900 prose-pre:text-gray-100">
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeRaw, rehypeSanitize]}
+              >
+                {report.markdown || note.executive_summary}
+              </ReactMarkdown>
+            </div>
+          )}
+
+          {/* Also render the markdown version below structured sections for full context */}
+          {s && report.markdown && (
+            <details className="mt-4">
+              <summary className="cursor-pointer text-sm text-muted-foreground hover:text-foreground">
+                Full analysis
+              </summary>
+              <div className="prose prose-slate mt-4 max-w-none prose-p:text-gray-700 prose-headings:text-gray-900 prose-a:text-primary prose-strong:text-gray-900 prose-code:text-gray-800 prose-code:bg-gray-100">
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm]}
+                  rehypePlugins={[rehypeRaw, rehypeSanitize]}
+                >
+                  {report.markdown}
+                </ReactMarkdown>
+              </div>
+            </details>
+          )}
 
           <p className="mt-8 text-sm text-muted-foreground">
             Generated by NeuFin Synthesis Agent at{" "}
@@ -232,8 +378,8 @@ export default async function ResearchArticlePage({
               Key Insights
             </h3>
             <ul className="space-y-2 text-sm text-muted-foreground">
-              {keyInsights.map((k) => (
-                <li key={k}>• {k}</li>
+              {keyInsights.map((k, i) => (
+                <li key={i}>• {k}</li>
               ))}
             </ul>
           </div>

--- a/neufin-web/app/upload/page.tsx
+++ b/neufin-web/app/upload/page.tsx
@@ -2,6 +2,7 @@
 
 import { Suspense, useState, useRef, DragEvent, ChangeEvent } from "react";
 import { useRouter } from "next/navigation";
+import Image from "next/image";
 import Link from "next/link";
 import { analyzeDNA } from "@/lib/api";
 import { useAuth } from "@/lib/auth-context";
@@ -100,7 +101,7 @@ export default function UploadPage() {
       <div className="min-h-screen flex flex-col">
         <nav className="border-b border-shell-border/60 bg-shell-deep/80 backdrop-blur-sm sticky top-0 z-10">
           <div className="max-w-4xl mx-auto px-6 h-16 flex items-center gap-4">
-            <span className="text-xl font-bold text-gradient">Neufin</span>
+            <Image src="/logo.png" alt="NeuFin" width={160} height={40} className="h-11 w-auto brightness-0 invert" priority />
           </div>
         </nav>
         <main className="flex-1 flex items-center justify-center p-6">
@@ -165,7 +166,7 @@ export default function UploadPage() {
           >
             ← Back
           </Link>
-          <span className="text-xl font-bold text-gradient">Neufin</span>
+          <Image src="/logo.png" alt="NeuFin" width={160} height={40} className="h-11 w-auto brightness-0 invert" />
         </div>
       </nav>
 

--- a/neufin-web/components/AppHeader.tsx
+++ b/neufin-web/components/AppHeader.tsx
@@ -98,14 +98,15 @@ export default function AppHeader() {
 
   return (
     <header className="sticky top-0 z-30 border-b border-border bg-white/95 backdrop-blur-sm">
-      <div className="mx-auto flex h-14 max-w-screen-xl items-center justify-between gap-4 px-4">
-        <Link href="/dashboard" className="shrink-0">
+      <div className="mx-auto flex h-16 max-w-screen-xl items-center justify-between gap-4 px-4">
+        <Link href="/dashboard" className="shrink-0 flex-none">
           <Image
             src="/logo.png"
             alt="NeuFin"
-            width={140}
-            height={36}
-            className="h-9 w-auto"
+            width={160}
+            height={40}
+            className="h-12 w-auto"
+            priority
           />
         </Link>
 

--- a/neufin-web/components/BrandLogo.tsx
+++ b/neufin-web/components/BrandLogo.tsx
@@ -43,7 +43,7 @@ export function BrandLogo({
       width={160}
       height={40}
       className={[sizeCls, darkCls, className].filter(Boolean).join(" ")}
-      priority={priority ?? size === "lg" || size === "xl"}
+      priority={priority ?? (size === "lg" || size === "xl")}
     />
   );
 

--- a/neufin-web/components/BrandLogo.tsx
+++ b/neufin-web/components/BrandLogo.tsx
@@ -1,34 +1,57 @@
 import Image from "next/image";
 import Link from "next/link";
 
-type Variant = "nav" | "sidebar" | "footer" | "footer-dark";
+/**
+ * Size scale:
+ *   sm  → h-9  (36px)  footer, compact areas
+ *   md  → h-10 (40px)  sidebar
+ *   lg  → h-12 (48px)  main nav, dashboard header, mobile
+ *   xl  → h-14 (56px)  auth pages, hero moments
+ */
+type Size = "sm" | "md" | "lg" | "xl";
 
-const SIZE: Record<Variant, { width: number; height: number; cls: string }> = {
-  nav:         { width: 160, height: 40, cls: "h-10 w-auto" },
-  sidebar:     { width: 140, height: 36, cls: "h-9 w-auto" },
-  footer:      { width: 140, height: 36, cls: "h-9 w-auto" },
-  "footer-dark": { width: 140, height: 36, cls: "h-9 w-auto brightness-0 invert" },
+const SIZE_MAP: Record<Size, string> = {
+  sm: "h-9 w-auto",
+  md: "h-10 w-auto",
+  lg: "h-12 w-auto",
+  xl: "h-14 w-auto",
 };
 
 interface BrandLogoProps {
-  variant?: Variant;
+  size?: Size;
+  /** Apply brightness-0 invert for dark backgrounds */
+  dark?: boolean;
   href?: string;
   className?: string;
+  priority?: boolean;
 }
 
-export function BrandLogo({ variant = "nav", href = "/", className }: BrandLogoProps) {
-  const { width, height, cls } = SIZE[variant];
+export function BrandLogo({
+  size = "lg",
+  dark = false,
+  href = "/",
+  className,
+  priority,
+}: BrandLogoProps) {
+  const sizeCls = SIZE_MAP[size];
+  const darkCls = dark ? "brightness-0 invert" : "";
 
   const img = (
     <Image
       src="/logo.png"
       alt="NeuFin"
-      width={width}
-      height={height}
-      className={`${cls} ${className ?? ""}`.trim()}
-      priority={variant === "nav"}
+      width={160}
+      height={40}
+      className={[sizeCls, darkCls, className].filter(Boolean).join(" ")}
+      priority={priority ?? size === "lg" || size === "xl"}
     />
   );
 
-  return href ? <Link href={href} className="shrink-0">{img}</Link> : img;
+  return href ? (
+    <Link href={href} className="shrink-0 flex-none">
+      {img}
+    </Link>
+  ) : (
+    img
+  );
 }

--- a/neufin-web/components/DashboardSidebar.tsx
+++ b/neufin-web/components/DashboardSidebar.tsx
@@ -235,13 +235,14 @@ export default function DashboardSidebar({
       aria-label={embedded ? undefined : "Main navigation"}
     >
       {!embedded && (
-        <div className="flex h-16 shrink-0 items-center justify-center border-b border-[#F1F5F9] bg-gradient-to-r from-white to-[#F8FAFC] px-5">
+        <div className="flex h-[72px] shrink-0 items-center border-b border-[#F1F5F9] bg-gradient-to-r from-white to-[#F8FAFC] px-5">
           <Image
             src="/logo.png"
             alt="NeuFin"
-            width={140}
-            height={36}
-            className="h-9 w-auto shrink-0 object-contain object-left"
+            width={160}
+            height={40}
+            className="h-11 w-auto shrink-0 object-contain object-left"
+            priority
           />
         </div>
       )}

--- a/neufin-web/components/dashboard/DashboardShell.tsx
+++ b/neufin-web/components/dashboard/DashboardShell.tsx
@@ -81,9 +81,9 @@ export function DashboardShell({
             onClick={() => setMobileNavOpen(false)}
           />
           <aside className="relative z-10 flex h-full w-72 max-w-[min(18rem,88vw)] flex-col bg-white shadow-2xl">
-            <div className="flex h-16 flex-shrink-0 items-center justify-between border-b border-[#E2E8F0] px-5">
+            <div className="flex h-[72px] flex-shrink-0 items-center justify-between border-b border-[#E2E8F0] px-5">
               <div className="flex items-center">
-                <BrandLogo variant="sidebar" href="/dashboard" />
+                <BrandLogo size="lg" href="/dashboard" />
               </div>
               <button
                 type="button"
@@ -102,7 +102,7 @@ export function DashboardShell({
       ) : null}
 
       <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-        <header className="flex h-14 flex-shrink-0 items-center gap-4 border-b border-[#E2E8F0] bg-white px-4 lg:hidden">
+        <header className="flex h-16 flex-shrink-0 items-center gap-4 border-b border-[#E2E8F0] bg-white px-4 lg:hidden">
           <button
             type="button"
             className="flex h-9 w-9 items-center justify-center rounded-lg text-[#334155] transition-colors hover:bg-[#F8FAFC]"
@@ -112,7 +112,7 @@ export function DashboardShell({
             <Menu className="h-5 w-5" strokeWidth={1.5} />
           </button>
           <div className="flex items-center">
-            <BrandLogo variant="sidebar" href="/dashboard" />
+            <BrandLogo size="lg" href="/dashboard" />
           </div>
         </header>
         <CommandBar

--- a/neufin-web/components/landing/Footer.tsx
+++ b/neufin-web/components/landing/Footer.tsx
@@ -34,9 +34,9 @@ export default function Footer() {
             <Image
               src="/logo.png"
               alt="NeuFin"
-              width={140}
-              height={36}
-              className="h-9 w-auto"
+              width={160}
+              height={40}
+              className="h-10 w-auto"
             />
             <p className="mt-3 max-w-md text-sm leading-relaxed text-muted-foreground">
               IC-grade portfolio intelligence in about a minute. Built for

--- a/neufin-web/components/landing/HomeLandingPage.tsx
+++ b/neufin-web/components/landing/HomeLandingPage.tsx
@@ -216,13 +216,13 @@ export default function HomeLandingPage({
         }`}
       >
         <div className="mx-auto flex h-full max-w-7xl items-center justify-between px-6">
-          <Link href="/" className="flex-shrink-0">
+          <Link href="/" className="flex-shrink-0 flex-none">
             <Image
               src="/logo.png"
               alt="NeuFin"
               width={160}
               height={40}
-              className="h-10 w-auto"
+              className="h-12 w-auto"
               priority
             />
           </Link>
@@ -1034,7 +1034,7 @@ export default function HomeLandingPage({
                 alt="NeuFin"
                 width={160}
                 height={40}
-                className="mb-5 h-10 w-auto brightness-0 invert"
+                className="mb-5 h-12 w-auto brightness-0 invert"
               />
               <p className="mb-4 text-sm leading-[1.7] text-slate-400">
                 Institutional-grade portfolio intelligence for advisors, IFAs,

--- a/neufin-web/components/landing/LandingNav.tsx
+++ b/neufin-web/components/landing/LandingNav.tsx
@@ -20,7 +20,7 @@ export default function LandingNav() {
   return (
     <nav className="fixed top-0 left-0 right-0 z-50 border-b border-border/40 bg-background/80 backdrop-blur-xl">
       <div className="mx-auto max-w-7xl px-6">
-        <div className="flex h-14 items-center justify-between gap-3">
+        <div className="flex h-16 items-center justify-between gap-3">
           <Link
             href="/"
             className="flex min-w-0 flex-none items-center gap-3"
@@ -31,7 +31,8 @@ export default function LandingNav() {
               alt="NeuFin"
               width={160}
               height={40}
-              className="h-10 w-auto"
+              className="h-12 w-auto"
+              priority
             />
           </Link>
 

--- a/neufin-web/components/pricing/PricingPageClient.tsx
+++ b/neufin-web/components/pricing/PricingPageClient.tsx
@@ -109,9 +109,9 @@ export default function PricingPageClient() {
   return (
     <div className="flex min-h-screen flex-col bg-[var(--bg-app)]">
       <nav className="sticky top-0 z-10 border-b border-[var(--border)] bg-white/95 backdrop-blur-md">
-        <div className="max-w-6xl mx-auto px-4 sm:px-6 h-14 flex items-center justify-between">
-          <Link href="/" className="shrink-0">
-            <Image src="/logo.png" alt="NeuFin" width={140} height={36} className="h-9 w-auto" />
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 h-16 flex items-center justify-between">
+          <Link href="/" className="shrink-0 flex-none">
+            <Image src="/logo.png" alt="NeuFin" width={160} height={40} className="h-12 w-auto" priority />
           </Link>
           <div className="flex gap-2">
             <Link href="/upload" className="btn-secondary px-3 py-2 text-sm">
@@ -292,9 +292,9 @@ export default function PricingPageClient() {
           <Image
             src="/logo.png"
             alt="NeuFin"
-            width={140}
-            height={36}
-            className="mb-3 h-9 w-auto"
+            width={160}
+            height={40}
+            className="mb-3 h-10 w-auto"
           />
           <span>NeuFin © {new Date().getFullYear()}</span>
         </div>

--- a/neufin-web/lib/research-normalizer.ts
+++ b/neufin-web/lib/research-normalizer.ts
@@ -1,0 +1,199 @@
+/**
+ * Research content normalization.
+ *
+ * The backend may emit `content` as:
+ *  1. Clean markdown prose (ideal path)
+ *  2. A JSON string (dict serialized from LLM structured output)
+ *  3. A JSON-like string with loose formatting
+ *
+ * This module normalizes all three into a typed `NormalizedReport`
+ * so the rendering layer never has to deal with raw JSON.
+ */
+
+export type KeyFinding = {
+  finding: string;
+  data_support?: string;
+  implication?: string;
+};
+
+export type SectorImpact = {
+  sector: string;
+  impact: string;
+  direction?: string;
+};
+
+export type NormalizedReport = {
+  /** Full markdown prose — always present, may be derived from structured fields */
+  markdown: string;
+  /** Structured sections — only present when the payload was a JSON dict */
+  structured?: {
+    thesis?: string;
+    key_findings?: KeyFinding[];
+    sector_impacts?: SectorImpact[];
+    portfolio_implications?: string[];
+    risks?: string[];
+    conclusion?: string;
+    recommended_action?: string;
+  };
+};
+
+function safeParseJson(raw: string): Record<string, unknown> | null {
+  const trimmed = raw.trim();
+  // Remove common LLM artifacts: leading/trailing fences, parentheses
+  const cleaned = trimmed
+    .replace(/^```(?:json)?\s*/i, "")
+    .replace(/\s*```$/, "")
+    .replace(/^\(\s*/, "")
+    .replace(/\s*\)$/, "");
+
+  if (!cleaned.startsWith("{")) return null;
+  try {
+    const parsed = JSON.parse(cleaned);
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function toStringArray(val: unknown): string[] {
+  if (!val) return [];
+  if (typeof val === "string") return [val];
+  if (Array.isArray(val)) {
+    return val.map((v) =>
+      typeof v === "object" && v !== null
+        ? Object.values(v).filter(Boolean).join(" — ")
+        : String(v ?? ""),
+    ).filter(Boolean);
+  }
+  return [];
+}
+
+function toKeyFindings(val: unknown): KeyFinding[] {
+  if (!Array.isArray(val)) return [];
+  return val
+    .map((item) => {
+      if (typeof item === "string") return { finding: item };
+      if (typeof item === "object" && item !== null) {
+        const o = item as Record<string, unknown>;
+        return {
+          finding: String(o.finding ?? o.text ?? o.description ?? ""),
+          data_support: o.data_support ? String(o.data_support) : undefined,
+          implication: o.implication ? String(o.implication) : undefined,
+        };
+      }
+      return null;
+    })
+    .filter((f): f is KeyFinding => f !== null && f.finding.length > 0);
+}
+
+function toSectorImpacts(val: unknown): SectorImpact[] {
+  if (!Array.isArray(val)) return [];
+  return val
+    .map((item) => {
+      if (typeof item === "object" && item !== null) {
+        const o = item as Record<string, unknown>;
+        return {
+          sector: String(o.sector ?? o.name ?? ""),
+          impact: String(o.impact ?? o.description ?? ""),
+          direction: o.direction ? String(o.direction) : undefined,
+        };
+      }
+      return null;
+    })
+    .filter((s): s is SectorImpact => s !== null && s.sector.length > 0);
+}
+
+function structuredToMarkdown(data: Record<string, unknown>): string {
+  const parts: string[] = [];
+
+  const thesis = data.thesis ?? data.executive_summary;
+  if (typeof thesis === "string" && thesis.trim()) {
+    parts.push(thesis.trim());
+    parts.push("");
+  }
+
+  const findings = toKeyFindings(data.key_findings);
+  if (findings.length) {
+    parts.push("## Key Findings\n");
+    for (const f of findings) {
+      parts.push(`- **${f.finding}**`);
+      if (f.data_support) parts.push(`  *${f.data_support}*`);
+      if (f.implication) parts.push(`  → ${f.implication}`);
+    }
+    parts.push("");
+  }
+
+  const impacts = toSectorImpacts(data.sector_impacts);
+  if (impacts.length) {
+    parts.push("## Sector Impacts\n");
+    for (const s of impacts) {
+      const dir = s.direction ? ` (${s.direction})` : "";
+      parts.push(`- **${s.sector}${dir}**: ${s.impact}`);
+    }
+    parts.push("");
+  }
+
+  const implications = toStringArray(data.portfolio_implications);
+  if (implications.length) {
+    parts.push("## Portfolio Implications\n");
+    implications.forEach((i) => parts.push(`- ${i}`));
+    parts.push("");
+  }
+
+  const risks = toStringArray(data.risks);
+  if (risks.length) {
+    parts.push("## Risk Factors\n");
+    risks.forEach((r) => parts.push(`- ${r}`));
+    parts.push("");
+  }
+
+  const conclusion = data.conclusion ?? data.recommended_action;
+  if (typeof conclusion === "string" && conclusion.trim()) {
+    parts.push("## Conclusion\n");
+    parts.push(conclusion.trim());
+  }
+
+  return parts.join("\n").trim();
+}
+
+/**
+ * Normalize raw content from the API into a `NormalizedReport`.
+ * Never throws — falls back to treating the raw string as markdown.
+ */
+export function normalizeResearchContent(
+  rawContent: string | null | undefined,
+  executiveSummary?: string,
+): NormalizedReport {
+  const raw = (rawContent ?? "").trim();
+
+  if (!raw) {
+    return { markdown: executiveSummary ?? "" };
+  }
+
+  // Attempt JSON parse
+  const parsed = safeParseJson(raw);
+  if (parsed) {
+    const structured = {
+      thesis: parsed.thesis
+        ? String(parsed.thesis)
+        : parsed.executive_summary
+          ? String(parsed.executive_summary)
+          : undefined,
+      key_findings: toKeyFindings(parsed.key_findings),
+      sector_impacts: toSectorImpacts(parsed.sector_impacts),
+      portfolio_implications: toStringArray(parsed.portfolio_implications),
+      risks: toStringArray(parsed.risks),
+      conclusion: parsed.conclusion ? String(parsed.conclusion) : undefined,
+      recommended_action: parsed.recommended_action
+        ? String(parsed.recommended_action)
+        : undefined,
+    };
+    const markdown = structuredToMarkdown(parsed) || executiveSummary || "";
+    return { markdown, structured };
+  }
+
+  // Already markdown or plain text — pass through
+  return { markdown: raw };
+}


### PR DESCRIPTION
## Summary

- **Logo system-wide upgrade**: Refactored `BrandLogo.tsx` to a clean `size` prop API (sm/md/lg/xl). Bumped all logo heights across landing nav, dashboard header, sidebar, mobile header, footer, features, pricing, and upload pages. Increased nav/header container heights for proper breathing room.
- **Upload page loading state**: Replaced fallback text "Neufin" with the actual logo image.
- **Research content normalization (backend)**: Added `_dict_to_markdown()` helper in `routers/research.py`. When the LLM stores structured JSON as content, the backend now converts it to clean markdown prose — eliminating raw JSON leaking into the UI.
- **Research content normalization (frontend)**: New `lib/research-normalizer.ts` safely parses JSON/markdown/plain-text content. Research article page renders structured sections (Key Findings, Sector Impacts, Portfolio Implications, Risks, Conclusion) as premium UI cards when structured, falls back to ReactMarkdown for prose.

## Logo size reference

| Context | Before | After |
|---|---|---|
| Landing nav | h-10 (40px) | h-12 (48px) |
| Dashboard header | h-9 (36px) | h-12 (48px) |
| Dashboard sidebar | h-9 (36px) | h-11 (44px) |
| Mobile header/drawer | h-9 (36px) | h-12 (48px) |
| Footer | h-9 (36px) | h-10 (40px) |
| Upload loading | text | h-11 (44px) image |

## Test plan

- [ ] Landing nav, pricing nav, features nav — logo is crisp and prominent (h-12)
- [ ] Dashboard sidebar — logo h-11 visible in gradient header bar
- [ ] Mobile drawer and sticky header — logo h-12 legible
- [ ] Footer — logo h-10, balanced
- [ ] Upload page loading skeleton — shows logo image, not text
- [ ] Research article with JSON-format content — renders structured cards, no raw JSON
- [ ] Research article with markdown content — renders via ReactMarkdown as before
- [ ] CI: Web CI, Backend CI, Release Gate all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)