### PR TITLE
Web: global contrast tokens, BrandLogo, shell/upload/research polish

### DIFF
--- a/neufin-web/app/admin/AdminShell.tsx
+++ b/neufin-web/app/admin/AdminShell.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { BrandLogo } from "@/components/BrandLogo";
 import { usePathname } from "next/navigation";
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
@@ -39,7 +40,7 @@ function AdminNavLinks({
               "rounded-lg px-3 py-2 text-sm transition-colors",
               active
                 ? "bg-zinc-800 text-white"
-                : "text-zinc-400 hover:bg-zinc-900 hover:text-zinc-200",
+                : "text-zinc-300 hover:bg-zinc-900 hover:text-white",
             )}
           >
             {label}
@@ -78,13 +79,7 @@ export default function AdminShell({ children }: { children: ReactNode }) {
             height={32}
             className="h-8 w-8 rounded-sm"
           />
-          <Image
-            src="/logo.png"
-            alt="NeuFin"
-            width={120}
-            height={32}
-            className="h-8 w-auto"
-          />
+          <BrandLogo variant="admin-wordmark" href="/admin" />
           <span className="sr-only">NeuFin Admin</span>
         </div>
         <button
@@ -130,13 +125,7 @@ export default function AdminShell({ children }: { children: ReactNode }) {
                   height={32}
                   className="h-8 w-8 rounded-sm"
                 />
-                <Image
-                  src="/logo.png"
-                  alt="NeuFin"
-                  width={120}
-                  height={32}
-                  className="h-8 w-auto"
-                />
+                <BrandLogo variant="admin-wordmark" href="/admin" />
               </div>
               <p className="text-xs font-semibold uppercase tracking-widest text-zinc-500">
                 Admin
@@ -160,13 +149,7 @@ export default function AdminShell({ children }: { children: ReactNode }) {
               height={32}
               className="h-8 w-8 rounded-sm"
             />
-            <Image
-              src="/logo.png"
-              alt="NeuFin"
-              width={120}
-              height={32}
-              className="h-8 w-auto"
-            />
+            <BrandLogo variant="admin-wordmark" href="/admin" />
           </div>
           <p className="text-xs font-semibold uppercase tracking-widest text-zinc-500">
             Admin

--- a/neufin-web/app/blog/layout.tsx
+++ b/neufin-web/app/blog/layout.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import Image from "next/image";
+import { BrandLogo } from "@/components/BrandLogo";
 
 export default function BlogLayout({
   children,
@@ -11,9 +11,7 @@ export default function BlogLayout({
       {/* Nav */}
       <nav className="border-b border-shell-border/60 sticky top-0 z-10 bg-shell-deep/90 backdrop-blur-sm">
         <div className="max-w-3xl mx-auto px-6 h-14 flex items-center justify-between">
-          <Link href="/" className="text-lg font-bold text-gradient">
-            NeuFin
-          </Link>
+          <BrandLogo variant="marketing-footer-dark" href="/" />
           <div className="flex items-center gap-4 text-sm">
             <Link
               href="/blog"
@@ -41,13 +39,9 @@ export default function BlogLayout({
       <footer className="border-t border-shell-border mt-16">
         <div className="max-w-3xl mx-auto px-6 py-section flex flex-wrap items-center justify-between gap-4">
           <div>
-            <Image
-              src="/logo.png"
-              alt="NeuFin"
-              width={90}
-              height={26}
-              className="h-6 w-auto mb-3 opacity-80"
-            />
+            <div className="mb-3">
+              <BrandLogo variant="research-footer" href="/" />
+            </div>
             <p className="text-xs text-shell-subtle mt-1">
               Behavioral finance intelligence for SEA SMEs · Founded 2025 ·
               Singapore

--- a/neufin-web/app/components/RootProviders.tsx
+++ b/neufin-web/app/components/RootProviders.tsx
@@ -47,15 +47,41 @@ export default function RootProviders({
           position="bottom-right"
           toastOptions={{
             duration: 4000,
+            className: "",
             style: {
               background: "var(--glass-bg)",
               color: "var(--text-primary)",
               border: "1px solid var(--glass-border)",
               borderRadius: "12px",
               fontSize: "14px",
+              fontWeight: 500,
               backdropFilter: "blur(12px)",
+              boxShadow: "var(--shadow-md)",
             },
-            error: { duration: 6000 },
+            success: {
+              duration: 3500,
+              style: {
+                background: "var(--success-bg)",
+                color: "var(--text-primary)",
+                border: "1px solid rgba(34, 197, 94, 0.35)",
+              },
+              iconTheme: {
+                primary: "var(--success)",
+                secondary: "var(--surface)",
+              },
+            },
+            error: {
+              duration: 6000,
+              style: {
+                background: "var(--danger-bg)",
+                color: "var(--text-primary)",
+                border: "1px solid rgba(239, 68, 68, 0.35)",
+              },
+              iconTheme: {
+                primary: "var(--danger)",
+                secondary: "var(--surface)",
+              },
+            },
           }}
         />
       </AuthProvider>

--- a/neufin-web/app/contact-sales/page.tsx
+++ b/neufin-web/app/contact-sales/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import Image from "next/image";
+import { BrandLogo } from "@/components/BrandLogo";
 
 const API = process.env.NEXT_PUBLIC_API_URL;
 
@@ -65,9 +65,7 @@ export default function ContactSalesPage() {
     <div className="min-h-screen bg-shell-deep flex flex-col">
       <nav className="border-b border-shell-border/60 backdrop-blur-sm sticky top-0 z-10 bg-shell-deep/80">
         <div className="max-w-6xl mx-auto px-6 h-16 flex items-center justify-between">
-          <Link href="/" className="text-xl font-bold text-gradient">
-            Neufin
-          </Link>
+          <BrandLogo variant="marketing-footer-dark" href="/" />
           <Link
             href="/pricing"
             className="text-shell-muted hover:text-white text-sm transition-colors"
@@ -81,7 +79,7 @@ export default function ContactSalesPage() {
         <div className="max-w-2xl mx-auto">
           {/* Header */}
           <div className="text-center mb-12">
-            <span className="badge bg-purple-500/10 text-purple-400 border border-purple-500/20 mb-4 inline-block">
+            <span className="badge border border-purple-400/35 bg-purple-500/15 text-purple-200 mb-4 inline-block">
               Enterprise Sales
             </span>
             <h1 className="text-3xl md:text-4xl font-extrabold mb-4">
@@ -239,7 +237,7 @@ export default function ContactSalesPage() {
                 )}
               </button>
 
-              <p className="text-center text-xs text-slate-500">
+              <p className="text-center text-xs text-shell-muted">
                 We&apos;ll contact you within 24 hours · No spam, ever
               </p>
             </form>
@@ -247,15 +245,11 @@ export default function ContactSalesPage() {
         </div>
       </main>
 
-      <footer className="border-t border-shell-border/60 py-6 text-center text-sm text-shell-subtle">
+      <footer className="border-t border-shell-border/60 py-6 text-center text-sm text-shell-muted">
         <div className="mx-auto flex max-w-3xl flex-col items-center justify-center">
-          <Image
-            src="/logo.png"
-            alt="NeuFin"
-            width={90}
-            height={26}
-            className="mb-3 h-6 w-auto opacity-80"
-          />
+          <div className="mb-3 flex justify-center">
+            <BrandLogo variant="marketing-footer-dark" href="/" />
+          </div>
           <span>
             NeuFin © {new Date().getFullYear()} · Singapore · MAS-compliant
           </span>

--- a/neufin-web/app/globals.css
+++ b/neufin-web/app/globals.css
@@ -84,6 +84,21 @@
   --bg-elevated: #f8fafc;
   /** Muted body on white — darker than legacy --subtle for small text AA */
   --readable-muted: #52607a;
+
+  /* App-wide semantic UI aliases (use with Tailwind `ui-*` or `text-readable`) */
+  --ui-text-primary: var(--text-primary);
+  --ui-text-secondary: var(--text-body);
+  --ui-text-muted: var(--readable-muted);
+  --ui-text-inverse: var(--shell-fg);
+  --ui-surface-default: var(--surface);
+  --ui-surface-elevated: var(--surface-2);
+  --ui-surface-accent: var(--primary-light);
+  --ui-border-subtle: var(--border-subtle);
+  --ui-border-strong: #cbd5e1;
+  --status-success: var(--success);
+  --status-warning: var(--warning);
+  --status-danger: var(--danger);
+  --status-info: var(--primary);
 }
 
 html {
@@ -159,11 +174,11 @@ span:not(.badge):not(.chip) {
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--text-secondary);
+  color: var(--readable-muted);
 }
 .text-caption {
   font-size: 0.875rem;
-  color: var(--text-secondary);
+  color: var(--readable-muted);
   line-height: 1.5;
 }
 .text-metric {
@@ -183,8 +198,8 @@ span:not(.badge):not(.chip) {
 .card,
 .card-sm,
 .card-elevated {
-  background: #ffffff;
-  border: 1px solid #e5e7eb;
+  background: var(--ui-surface-default);
+  border: 1px solid var(--ui-border-subtle);
   border-radius: 0.75rem;
   box-shadow: 0 1px 2px 0 rgb(15 23 42 / 0.05);
   transition:
@@ -227,6 +242,12 @@ span:not(.badge):not(.chip) {
 }
 .btn-primary:hover {
   background: var(--primary-dark);
+}
+.btn-primary:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 2px var(--surface),
+    0 0 0 4px var(--primary);
 }
 
 .btn-secondary {

--- a/neufin-web/app/partners/page.tsx
+++ b/neufin-web/app/partners/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from "react";
 import Link from "next/link";
-import Image from "next/image";
+import { BrandLogo } from "@/components/BrandLogo";
 
 // ─── types ────────────────────────────────────────────────────────────────────
 type DemoStatus = "idle" | "analyzing" | "done" | "error";
@@ -486,15 +486,9 @@ export default function PartnersPage() {
             justifyContent: "space-between",
           }}
         >
-          <Link href="/" style={{ textDecoration: "none" }}>
-            <Image
-              src="/logo.png"
-              alt="NeuFin"
-              width={130}
-              height={34}
-              style={{ height: 34, width: "auto" }}
-            />
-          </Link>
+          <div style={{ display: "flex", alignItems: "center" }}>
+            <BrandLogo variant="marketing-nav" href="/" />
+          </div>
           <div
             style={{
               display: "flex",
@@ -505,19 +499,19 @@ export default function PartnersPage() {
           >
             <a
               href="#sandbox"
-              style={{ color: "#64748B", textDecoration: "none" }}
+              style={{ color: "var(--readable-muted)", textDecoration: "none" }}
             >
               Live Demo
             </a>
             <a
               href="#pricing"
-              style={{ color: "#64748B", textDecoration: "none" }}
+              style={{ color: "var(--readable-muted)", textDecoration: "none" }}
             >
               Pricing
             </a>
             <a
               href="#integration"
-              style={{ color: "#64748B", textDecoration: "none" }}
+              style={{ color: "var(--readable-muted)", textDecoration: "none" }}
             >
               Docs
             </a>

--- a/neufin-web/app/upload/page.tsx
+++ b/neufin-web/app/upload/page.tsx
@@ -2,8 +2,8 @@
 
 import { Suspense, useState, useRef, DragEvent, ChangeEvent } from "react";
 import { useRouter } from "next/navigation";
-import Image from "next/image";
 import Link from "next/link";
+import { BrandLogo } from "@/components/BrandLogo";
 import { analyzeDNA } from "@/lib/api";
 import { useAuth } from "@/lib/auth-context";
 import RefCapture from "@/components/RefCapture";
@@ -98,10 +98,10 @@ export default function UploadPage() {
 
   if (loading) {
     return (
-      <div className="min-h-screen flex flex-col">
+      <div className="min-h-screen flex flex-col bg-shell text-shell-fg">
         <nav className="border-b border-shell-border/60 bg-shell-deep/80 backdrop-blur-sm sticky top-0 z-10">
           <div className="max-w-4xl mx-auto px-6 h-16 flex items-center gap-4">
-            <Image src="/logo.png" alt="NeuFin" width={160} height={40} className="h-11 w-auto brightness-0 invert" priority />
+            <BrandLogo variant="shell-inverted" href={null} priority />
           </div>
         </nav>
         <main className="flex-1 flex items-center justify-center p-6">
@@ -154,7 +154,7 @@ export default function UploadPage() {
   }
 
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="min-h-screen flex flex-col bg-shell text-shell-fg">
       <Suspense fallback={null}>
         <RefCapture />
       </Suspense>
@@ -166,13 +166,13 @@ export default function UploadPage() {
           >
             ← Back
           </Link>
-          <Image src="/logo.png" alt="NeuFin" width={160} height={40} className="h-11 w-auto brightness-0 invert" />
+          <BrandLogo variant="shell-inverted" href="/" />
         </div>
       </nav>
 
       <main className="flex-1 flex items-center justify-center p-6">
         <div className="w-full max-w-xl">
-          <h1 className="text-3xl font-bold mb-2">Upload your portfolio</h1>
+          <h1 className="text-3xl font-bold mb-2 text-shell-fg">Upload your portfolio</h1>
           <p className="text-shell-muted mb-4">
             CSV with columns: <code className="text-primary">symbol</code>,{" "}
             <code className="text-primary">shares</code>, and optional{" "}
@@ -252,19 +252,20 @@ export default function UploadPage() {
             </button>
 
             <button
+              type="button"
               onClick={downloadSample}
-              className="btn-outline w-full text-sm py-3"
+              className="btn-outline-on-dark w-full py-3 text-sm"
             >
               Download sample CSV
             </button>
           </div>
 
           {/* Format hint */}
-          <div className="mt-6 card text-sm">
-            <p className="text-shell-muted font-medium mb-2">
+          <div className="mt-6 rounded-xl border border-white/10 bg-white/[0.06] p-5 text-sm text-shell-fg shadow-sm backdrop-blur-sm">
+            <p className="text-shell-fg/90 font-medium mb-2">
               Expected CSV format:
             </p>
-            <pre className="text-xs text-shell-subtle font-mono leading-relaxed">
+            <pre className="text-xs text-shell-muted font-mono leading-relaxed">
               {SAMPLE_CSV.trim()}
             </pre>
           </div>

--- a/neufin-web/components/AppHeader.tsx
+++ b/neufin-web/components/AppHeader.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
-import Image from "next/image";
+import { BrandLogo } from "@/components/BrandLogo";
 import { useRouter, usePathname } from "next/navigation";
 import { useAuth } from "@/lib/auth-context";
 import { getSubscriptionStatus } from "@/lib/api";
@@ -36,7 +36,7 @@ function TrialBadge({
     );
   }
   return (
-    <span className="rounded border border-border bg-surface-2 px-2 py-0.5 text-sm font-semibold text-muted2">
+    <span className="rounded border border-border bg-surface-2 px-2 py-0.5 text-sm font-semibold text-slate2">
       Trial
     </span>
   );
@@ -99,16 +99,7 @@ export default function AppHeader() {
   return (
     <header className="sticky top-0 z-30 border-b border-border bg-white/95 backdrop-blur-sm">
       <div className="mx-auto flex h-16 max-w-screen-xl items-center justify-between gap-4 px-4">
-        <Link href="/dashboard" className="shrink-0 flex-none">
-          <Image
-            src="/logo.png"
-            alt="NeuFin"
-            width={160}
-            height={40}
-            className="h-12 w-auto"
-            priority
-          />
-        </Link>
+        <BrandLogo variant="app-header" href="/dashboard" />
 
         <nav className="hidden items-center gap-1 md:flex">
           {NAV_ITEMS.map(({ label, href }) => {

--- a/neufin-web/components/BrandLogo.tsx
+++ b/neufin-web/components/BrandLogo.tsx
@@ -1,57 +1,148 @@
 import Image from "next/image";
 import Link from "next/link";
+import clsx from "clsx";
 
 /**
- * Size scale:
- *   sm  → h-9  (36px)  footer, compact areas
- *   md  → h-10 (40px)  sidebar
- *   lg  → h-12 (48px)  main nav, dashboard header, mobile
- *   xl  → h-14 (56px)  auth pages, hero moments
+ * Single source for NeuFin wordmark sizing across marketing, auth, shell, and upload.
+ * Prefer `variant` over legacy `size` + `dark`.
  */
-type Size = "sm" | "md" | "lg" | "xl";
+export type BrandLogoVariant =
+  | "marketing-header"
+  | "marketing-nav"
+  | "marketing-footer-dark"
+  | "marketing-footer-light"
+  | "marketing-compact"
+  | "app-header"
+  | "app-sidebar"
+  | "app-command"
+  | "shell-inverted"
+  | "research-footer"
+  | "admin-wordmark";
 
-const SIZE_MAP: Record<Size, string> = {
+const VARIANTS: Record<
+  BrandLogoVariant,
+  { width: number; height: number; className: string }
+> = {
+  "marketing-header": {
+    width: 200,
+    height: 52,
+    className: "h-[3.25rem] w-auto sm:h-14",
+  },
+  "marketing-nav": {
+    width: 200,
+    height: 52,
+    className: "h-[3.25rem] w-auto sm:h-14",
+  },
+  "marketing-footer-dark": {
+    width: 200,
+    height: 52,
+    className: "h-14 w-auto sm:h-16 brightness-0 invert",
+  },
+  "marketing-footer-light": {
+    width: 200,
+    height: 52,
+    className: "h-12 w-auto sm:h-14",
+  },
+  "marketing-compact": {
+    width: 176,
+    height: 46,
+    className: "h-11 w-auto sm:h-12",
+  },
+  "app-header": {
+    width: 180,
+    height: 48,
+    className: "h-12 w-auto",
+  },
+  "app-sidebar": {
+    width: 180,
+    height: 48,
+    className: "h-11 w-auto shrink-0 object-contain object-left",
+  },
+  "app-command": {
+    width: 160,
+    height: 44,
+    className: "hidden h-9 w-auto sm:block",
+  },
+  "shell-inverted": {
+    width: 200,
+    height: 52,
+    className: "h-11 w-auto brightness-0 invert",
+  },
+  "research-footer": {
+    width: 160,
+    height: 42,
+    className: "h-8 w-auto sm:h-9 opacity-95",
+  },
+  "admin-wordmark": {
+    width: 140,
+    height: 36,
+    className: "h-8 w-auto brightness-0 invert",
+  },
+};
+
+/** @deprecated prefer BrandLogoVariant */
+type LegacySize = "sm" | "md" | "lg" | "xl";
+
+const LEGACY_SIZE_MAP: Record<LegacySize, string> = {
   sm: "h-9 w-auto",
   md: "h-10 w-auto",
   lg: "h-12 w-auto",
   xl: "h-14 w-auto",
 };
 
-interface BrandLogoProps {
-  size?: Size;
-  /** Apply brightness-0 invert for dark backgrounds */
+export interface BrandLogoProps {
+  variant?: BrandLogoVariant;
+  /** @deprecated use `variant` */
+  size?: LegacySize;
+  /** @deprecated use `variant` with `marketing-footer-dark` / `shell-inverted` */
   dark?: boolean;
-  href?: string;
+  href?: string | null;
   className?: string;
   priority?: boolean;
 }
 
 export function BrandLogo({
+  variant,
   size = "lg",
   dark = false,
   href = "/",
   className,
   priority,
 }: BrandLogoProps) {
-  const sizeCls = SIZE_MAP[size];
-  const darkCls = dark ? "brightness-0 invert" : "";
+  const resolved = variant
+    ? VARIANTS[variant]
+    : {
+        width: 160,
+        height: 40,
+        className: clsx(
+          LEGACY_SIZE_MAP[size],
+          dark && "brightness-0 invert",
+        ),
+      };
 
   const img = (
     <Image
       src="/logo.png"
       alt="NeuFin"
-      width={160}
-      height={40}
-      className={[sizeCls, darkCls, className].filter(Boolean).join(" ")}
-      priority={priority ?? (size === "lg" || size === "xl")}
+      width={resolved.width}
+      height={resolved.height}
+      className={clsx(resolved.className, className)}
+      priority={
+        priority ??
+        (variant
+          ? variant.startsWith("marketing") || variant === "app-header"
+          : size === "lg" || size === "xl")
+      }
     />
   );
 
-  return href ? (
-    <Link href={href} className="shrink-0 flex-none">
+  if (href === null) {
+    return img;
+  }
+
+  return (
+    <Link href={href} className="inline-flex shrink-0 items-center">
       {img}
     </Link>
-  ) : (
-    img
   );
 }

--- a/neufin-web/components/CommandBar.tsx
+++ b/neufin-web/components/CommandBar.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Bell, Sparkles } from "lucide-react";
 import { apiFetch } from "@/lib/api-client";
-import Image from "next/image";
+import { BrandLogo } from "@/components/BrandLogo";
 
 export type RegimeVariant = "risk-on" | "risk-off" | "neutral";
 
@@ -116,13 +116,7 @@ export function CommandBar({
     <>
       <header className="grid h-11 w-full shrink-0 grid-cols-1 items-center gap-2 border-b border-border bg-white px-4 sm:grid-cols-[1fr_minmax(0,28rem)_1fr] sm:gap-0">
         <div className="flex min-w-0 items-center gap-3">
-          <Image
-            src="/logo.png"
-            alt="NeuFin"
-            width={140}
-            height={40}
-            className="hidden h-9 w-auto sm:block"
-          />
+          <BrandLogo variant="app-command" href="/dashboard" />
           <span
             className="hidden h-4 w-px shrink-0 bg-border sm:block"
             aria-hidden

--- a/neufin-web/components/DashboardSidebar.tsx
+++ b/neufin-web/components/DashboardSidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import Image from "next/image";
+import { BrandLogo } from "@/components/BrandLogo";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import type { LucideIcon } from "lucide-react";
@@ -68,8 +68,8 @@ function NavLink({ item, pathname }: { item: NavItem; pathname: string }) {
       className={[
         "flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors duration-200 ease-out",
         active
-          ? "bg-[#E0F7FA] font-semibold text-primary"
-          : "text-[#334155] hover:bg-[#F8FAFC] hover:text-[#0F172A] active:scale-[0.99]",
+          ? "bg-primary-light font-semibold text-primary"
+          : "text-slate2 hover:bg-surface-2 hover:text-foreground active:scale-[0.99]",
       ].join(" ")}
     >
       <Icon
@@ -227,7 +227,7 @@ export default function DashboardSidebar({
 
   const rootClass = embedded
     ? "flex h-full min-h-0 w-full flex-col bg-white"
-    : "flex h-full w-[220px] shrink-0 flex-col border-r border-[#E5E7EB] bg-white";
+    : "flex h-full w-[220px] shrink-0 flex-col border-r border-border bg-white";
 
   return (
     <aside
@@ -235,32 +235,25 @@ export default function DashboardSidebar({
       aria-label={embedded ? undefined : "Main navigation"}
     >
       {!embedded && (
-        <div className="flex h-[72px] shrink-0 items-center border-b border-[#F1F5F9] bg-gradient-to-r from-white to-[#F8FAFC] px-5">
-          <Image
-            src="/logo.png"
-            alt="NeuFin"
-            width={160}
-            height={40}
-            className="h-11 w-auto shrink-0 object-contain object-left"
-            priority
-          />
+        <div className="flex h-[72px] shrink-0 items-center border-b border-border bg-gradient-to-r from-white to-surface-2 px-5">
+          <BrandLogo variant="app-sidebar" href="/dashboard" />
         </div>
       )}
 
       {sidebarDnaScore != null && (
-        <div className="mx-3 mb-2 mt-4 rounded-xl border border-[#1EB8CC]/20 bg-gradient-to-br from-[#E0F7FA] to-[#F0FDF4] p-3">
-          <p className="mb-1 text-xs font-bold uppercase tracking-widest text-[#1EB8CC]">
+        <div className="mx-3 mb-2 mt-4 rounded-xl border border-primary/25 bg-gradient-to-br from-primary-light to-emerald-50/90 p-3">
+          <p className="mb-1 text-xs font-bold uppercase tracking-widest text-primary">
             Portfolio Health
           </p>
           <div className="flex items-center justify-between gap-2">
-            <span className="text-[22px] font-bold tabular-nums tracking-tight text-[#0F172A]">
+            <span className="text-[22px] font-bold tabular-nums tracking-tight text-foreground">
               {sidebarDnaScore}
             </span>
             <span className="badge badge-success shrink-0 text-xs">Active</span>
           </div>
-          <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-[#E2E8F0]">
+          <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-border">
             <div
-              className="h-1.5 min-w-[4px] rounded-full bg-[#1EB8CC] transition-all duration-500"
+              className="h-1.5 min-w-[4px] rounded-full bg-primary transition-all duration-500"
               style={{
                 width: `${Math.min(100, Math.max(0, Number(sidebarDnaScore)))}%`,
               }}
@@ -292,7 +285,7 @@ export default function DashboardSidebar({
 
         {isActivePaid && (
           <>
-            <div className="mx-4 my-4 border-t border-[#F1F5F9]" />
+            <div className="mx-4 my-4 border-t border-border" />
             <div className="mt-0">
               <p className="text-label px-3 pb-1.5 pt-2">Developer</p>
               <div className="flex flex-col gap-0.5 px-2">
@@ -301,8 +294,8 @@ export default function DashboardSidebar({
                   className={[
                     "flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors",
                     isActivePath(pathname, "/developer")
-                      ? "bg-[#E0F7FA] font-semibold text-primary"
-                      : "text-[#334155] hover:bg-[#F8FAFC] hover:text-[#0F172A]",
+                      ? "bg-primary-light font-semibold text-primary"
+                      : "text-slate2 hover:bg-surface-2 hover:text-foreground",
                   ].join(" ")}
                 >
                   <Code2
@@ -323,7 +316,7 @@ export default function DashboardSidebar({
         )}
       </nav>
 
-      <div className="border-t border-[#F1F5F9] px-4 py-3">
+      <div className="border-t border-border px-4 py-3">
         <div
           className={`mb-3 rounded-md px-2.5 py-1.5 text-sm font-medium ${planBadgeClass}`}
         >
@@ -334,14 +327,14 @@ export default function DashboardSidebar({
             {initials}
           </div>
           <div className="min-w-0 flex-1">
-            <p className="truncate text-sm leading-snug text-[#64748B]">
+            <p className="truncate text-sm leading-snug text-readable">
               {user?.email ?? "—"}
             </p>
           </div>
           <button
             type="button"
             onClick={onSignOut}
-            className="shrink-0 rounded-md p-1.5 text-[#6B7280] hover:bg-slate-100 hover:text-slate-900"
+            className="shrink-0 rounded-md p-1.5 text-readable hover:bg-surface-2 hover:text-foreground"
             aria-label="Sign out"
           >
             <LogOut className="h-[14px] w-[14px]" strokeWidth={1.5} />

--- a/neufin-web/components/auth/AuthScreen.tsx
+++ b/neufin-web/components/auth/AuthScreen.tsx
@@ -8,6 +8,7 @@ import { supabase } from "@/lib/supabase";
 import { claimAnonymousRecord } from "@/lib/api";
 import { useNeufinAnalytics } from "@/lib/analytics";
 import { GlassCard } from "@/components/ui/GlassCard";
+import { BrandLogo } from "@/components/BrandLogo";
 
 async function claimPendingRecord(token: string) {
   if (typeof window === "undefined") return;
@@ -210,7 +211,7 @@ function AuthScreenInner({ initialMode }: { initialMode: "login" | "signup" }) {
               setError("");
               setEmail("");
             }}
-            className="text-sm text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors"
+            className="text-sm text-[var(--readable-muted)] hover:text-[var(--text-body)] transition-colors"
           >
             ← Try a different email
           </button>
@@ -229,13 +230,10 @@ function AuthScreenInner({ initialMode }: { initialMode: "login" | "signup" }) {
         transition={{ type: "spring", stiffness: 320, damping: 28 }}
       >
         <GlassCard className="p-8 space-y-6">
-          <div className="text-center space-y-2">
-            <Link
-              href="/"
-              className="inline-block font-sans text-2xl text-primary tracking-tight"
-            >
-              NeuFin
-            </Link>
+          <div className="text-center space-y-3">
+            <div className="flex justify-center">
+              <BrandLogo variant="marketing-compact" href="/" />
+            </div>
             <h1 className="text-xl font-semibold text-[var(--text-primary)]">
               {mode === "login"
                 ? "Sign in to NeuFin"
@@ -264,7 +262,7 @@ function AuthScreenInner({ initialMode }: { initialMode: "login" | "signup" }) {
             Continue with Google
           </motion.button>
 
-          <div className="flex items-center gap-3 text-xs text-[var(--text-muted)]">
+          <div className="flex items-center gap-3 text-xs text-[var(--readable-muted)]">
             <span className="h-px flex-1 bg-[var(--border)]" />
             or continue with email
             <span className="h-px flex-1 bg-[var(--border)]" />
@@ -299,7 +297,7 @@ function AuthScreenInner({ initialMode }: { initialMode: "login" | "signup" }) {
                 onChange={(e) => setEmail(e.target.value)}
                 placeholder="you@example.com"
                 autoComplete="email"
-                className="w-full rounded-lg bg-[var(--surface-2)] border border-[var(--glass-border)] px-3 py-2.5 text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus-amber"
+                className="w-full rounded-lg bg-[var(--surface-2)] border border-[var(--glass-border)] px-3 py-2.5 text-sm text-[var(--text-primary)] placeholder:text-[var(--readable-muted)] focus-amber"
               />
             </div>
             <div>
@@ -320,7 +318,7 @@ function AuthScreenInner({ initialMode }: { initialMode: "login" | "signup" }) {
                 autoComplete={
                   mode === "login" ? "current-password" : "new-password"
                 }
-                className="w-full rounded-lg bg-[var(--surface-2)] border border-[var(--glass-border)] px-3 py-2.5 text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus-amber"
+                className="w-full rounded-lg bg-[var(--surface-2)] border border-[var(--glass-border)] px-3 py-2.5 text-sm text-[var(--text-primary)] placeholder:text-[var(--readable-muted)] focus-amber"
               />
             </div>
 
@@ -344,7 +342,7 @@ function AuthScreenInner({ initialMode }: { initialMode: "login" | "signup" }) {
 
           <motion.div
             layout
-            className="text-center text-sm text-[var(--text-secondary)]"
+            className="text-center text-sm text-[var(--text-body)]"
           >
             {mode === "login" ? (
               <>
@@ -369,11 +367,11 @@ function AuthScreenInner({ initialMode }: { initialMode: "login" | "signup" }) {
             )}
           </motion.div>
 
-          <p className="text-center text-xs text-[var(--text-muted)]">
+          <p className="text-center text-xs text-[var(--readable-muted)]">
             By continuing you agree to our{" "}
             <Link
               href="/privacy"
-              className="text-[var(--text-secondary)] underline underline-offset-2 hover:text-[var(--text-primary)]"
+              className="text-[var(--text-body)] underline underline-offset-2 hover:text-[var(--text-primary)]"
             >
               Privacy Policy
             </Link>
@@ -383,7 +381,7 @@ function AuthScreenInner({ initialMode }: { initialMode: "login" | "signup" }) {
         <p className="text-center mt-6">
           <Link
             href="/"
-            className="text-sm text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+            className="text-sm text-[var(--readable-muted)] hover:text-[var(--text-body)]"
           >
             ← Back to home
           </Link>

--- a/neufin-web/components/landing/NeuFinLogo.tsx
+++ b/neufin-web/components/landing/NeuFinLogo.tsx
@@ -1,67 +1,24 @@
-import Image from "next/image";
 import type { ComponentProps } from "react";
+import { BrandLogo, type BrandLogoVariant } from "@/components/BrandLogo";
 
-const VARIANTS = {
-  /** Sticky header — marketing home & light nav */
-  header: {
-    width: 200,
-    height: 52,
-    className: "h-[3.25rem] w-auto sm:h-14",
-  },
-  /** App Router `LandingNav` — matches header with mobile tap target */
-  nav: {
-    width: 200,
-    height: 52,
-    className: "h-[3.25rem] w-auto sm:h-14",
-  },
-  /** Dark footer / inverted marks (e.g. home footer on navy) */
-  "footer-on-dark": {
-    width: 200,
-    height: 52,
-    className: "h-14 w-auto sm:h-16 brightness-0 invert",
-  },
-  /** Light surface footer (`components/landing/Footer.tsx`) */
-  "footer-on-light": {
-    width: 200,
-    height: 52,
-    className: "h-12 w-auto sm:h-14",
-  },
-  /** Compact chrome (pricing footer, dialogs) */
-  compact: {
-    width: 176,
-    height: 46,
-    className: "h-11 w-auto sm:h-12",
-  },
-} as const;
+/** Maps legacy marketing variant names → BrandLogo presets */
+const MAP: Record<string, BrandLogoVariant> = {
+  header: "marketing-header",
+  nav: "marketing-nav",
+  "footer-on-dark": "marketing-footer-dark",
+  "footer-on-light": "marketing-footer-light",
+  compact: "marketing-compact",
+};
 
-export type NeuFinLogoVariant = keyof typeof VARIANTS;
+export type NeuFinLogoVariant = keyof typeof MAP;
 
 type Props = {
   variant: NeuFinLogoVariant;
-  priority?: boolean;
-  className?: string;
-} & Omit<ComponentProps<typeof Image>, "src" | "alt" | "width" | "height">;
+} & Omit<ComponentProps<typeof BrandLogo>, "variant">;
 
 /**
- * Shared NeuFin wordmark sizing for marketing surfaces.
- * Width/height reserve layout; displayed size comes from `className` scales.
+ * @deprecated import `BrandLogo` from `@/components/BrandLogo` instead
  */
-export default function NeuFinLogo({
-  variant,
-  priority,
-  className = "",
-  ...rest
-}: Props) {
-  const v = VARIANTS[variant];
-  return (
-    <Image
-      src="/logo.png"
-      alt="NeuFin"
-      width={v.width}
-      height={v.height}
-      className={[v.className, className].filter(Boolean).join(" ")}
-      priority={priority}
-      {...rest}
-    />
-  );
+export default function NeuFinLogo({ variant, ...rest }: Props) {
+  return <BrandLogo variant={MAP[variant]} {...rest} />;
 }

--- a/neufin-web/components/research/ResearchHubClient.tsx
+++ b/neufin-web/components/research/ResearchHubClient.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import Image from "next/image";
+import { BrandLogo } from "@/components/BrandLogo";
 import { motion } from "framer-motion";
 import { Lock, Search } from "lucide-react";
 import { useAuth } from "@/lib/auth-context";
@@ -117,9 +117,7 @@ export default function ResearchHubClient({
     <div className="min-h-screen bg-app text-navy">
       <nav className="sticky top-0 z-10 border-b border-border bg-white/90 backdrop-blur-xl">
         <div className="max-w-5xl mx-auto px-4 sm:px-6 h-14 flex items-center justify-between">
-          <Link href="/" className="font-sans text-lg text-primary">
-            NeuFin
-          </Link>
+          <BrandLogo variant="marketing-nav" href="/" />
           <div className="flex gap-3 text-sm">
             <Link href="/blog" className="text-slate2 hover:text-navy">
               Blog
@@ -133,7 +131,7 @@ export default function ResearchHubClient({
 
       <div className="max-w-5xl mx-auto px-4 sm:px-6 py-section space-y-12">
         <header className="space-y-4">
-          <p className="text-sm font-medium uppercase tracking-wide text-muted2">
+          <p className="text-sm font-medium uppercase tracking-wide text-readable">
             Live intelligence
           </p>
           <h1 className="font-sans text-4xl md:text-5xl leading-tight">
@@ -168,12 +166,12 @@ export default function ResearchHubClient({
 
         <form onSubmit={runSearch} className="space-y-4">
           <GlassCard className="flex items-center gap-2 border-primary/25 p-2">
-            <Search className="ml-3 h-5 w-5 shrink-0 text-muted2" />
+            <Search className="ml-3 h-5 w-5 shrink-0 text-readable" />
             <input
               value={q}
               onChange={(e) => setQ(e.target.value)}
               placeholder="Search intelligence…"
-              className="flex-1 border-0 bg-transparent py-3 pr-3 text-sm text-navy placeholder:text-muted2 focus:outline-none focus:ring-0"
+              className="flex-1 border-0 bg-transparent py-3 pr-3 text-sm text-navy placeholder:text-readable focus:outline-none focus:ring-0"
             />
             <button
               type="submit"
@@ -190,7 +188,7 @@ export default function ResearchHubClient({
           )}
           {searchHits.length > 0 && (
             <div className="space-y-2">
-              <p className="text-sm text-muted2">Results</p>
+              <p className="text-sm font-medium text-readable">Results</p>
               {searchHits.map((h) => (
                 <GlassCard key={h.id || h.title} className="p-4">
                   {h.title && (
@@ -204,7 +202,7 @@ export default function ResearchHubClient({
                     </p>
                   )}
                   {h.similarity != null && (
-                    <p className="mt-2 font-mono text-sm text-muted2">
+                    <p className="mt-2 font-mono text-sm text-readable">
                       Match {(h.similarity * 100).toFixed(0)}%
                     </p>
                   )}
@@ -289,19 +287,13 @@ export default function ResearchHubClient({
       </div>
 
       <footer className="mt-12 border-t border-border px-4 py-6">
-        <div className="mx-auto flex max-w-5xl flex-wrap justify-between gap-4 text-sm text-muted2">
-          <Image
-            src="/logo.png"
-            alt="NeuFin"
-            width={90}
-            height={26}
-            className="h-6 w-auto opacity-80"
-          />
+        <div className="mx-auto flex max-w-5xl flex-wrap justify-between gap-4 text-sm text-readable">
+          <BrandLogo variant="research-footer" href="/" />
           <div className="flex gap-4">
-            <Link href="/pricing" className="hover:text-navy">
+            <Link href="/pricing" className="font-medium text-slate2 hover:text-foreground">
               Pricing
             </Link>
-            <Link href="/privacy" className="hover:text-navy">
+            <Link href="/privacy" className="font-medium text-slate2 hover:text-foreground">
               Privacy
             </Link>
           </div>

--- a/neufin-web/components/ui/GlassCard.tsx
+++ b/neufin-web/components/ui/GlassCard.tsx
@@ -5,7 +5,7 @@ import clsx from "clsx";
 
 /** Solid surface card (no glass blur). Hover: lift + shadow. */
 const surfaceCard =
-  "rounded-xl border border-gray-200 bg-white shadow-sm transition-shadow transition-transform duration-200 hover:shadow-md hover:-translate-y-0.5";
+  "rounded-xl border border-border bg-white shadow-sm transition-shadow transition-transform duration-200 hover:shadow-md hover:-translate-y-0.5";
 
 type GlassCardProps = HTMLMotionProps<"div">;
 

--- a/neufin-web/docs/frontend-ui-audit-checklist.md
+++ b/neufin-web/docs/frontend-ui-audit-checklist.md
@@ -1,0 +1,25 @@
+# Frontend UI audit checklist (Neufin web)
+
+Use this when reviewing new pages or refactors for contrast and consistency.
+
+## Primitives
+
+- [ ] **Text on light surfaces** — body uses `text-slate2` or `text-foreground`; muted uses `text-readable` / `text-ui-muted` / `text-lp-muted` (not raw `gray-400` for small text).
+- [ ] **Text on dark / shell** — `text-shell-fg`, `text-shell-muted`, `text-lp-on-dark` / `text-lp-on-dark-muted` as appropriate.
+- [ ] **Links** — visible default + hover; primary links `text-primary` with underline where needed.
+- [ ] **Buttons** — `btn-primary` / `btn-outline` / `btn-outline-on-dark` / `lp-btn-*`; focus-visible ring present.
+- [ ] **Inputs** — label `text-ui-text-secondary` or `text-shell-muted`; placeholder `placeholder:text-[var(--readable-muted)]` or equivalent.
+- [ ] **Disabled** — `opacity-50` + `cursor-not-allowed` + no information-only-glyph.
+- [ ] **Cards** — `border-border`, `bg-white` or `surface-*`; GlassCard uses token borders.
+- [ ] **Tables** — header distinct from body (`bg-surface-2`, `text-foreground` / `text-readable`).
+- [ ] **Badges / pills** — semantic colors with sufficient contrast (avoid light-on-light).
+- [ ] **Toasts** — themed via `RootProviders` (success/error backgrounds + borders).
+- [ ] **Modals** — focus trap + backdrop; body text meets contrast on modal surface.
+
+## Brand
+
+- [ ] **Logo** — `BrandLogo` with a named `variant` (no ad hoc `Image` + `logo.png` in chrome).
+
+## Tokens
+
+Canonical CSS variables live in `app/globals.css` (`:root`). Tailwind maps: `lp.*`, `ui.*`, `readable`, plus existing `primary`, `shell`, `surface`, `border`.

--- a/neufin-web/lib/design-tokens.ts
+++ b/neufin-web/lib/design-tokens.ts
@@ -34,3 +34,20 @@ export const designTokens = {
 } as const;
 
 export type DesignTokenKey = keyof typeof designTokens;
+
+/** Semantic names for product UI — mirrors `:root` / Tailwind `ui` colors */
+export const uiTokens = {
+  textPrimary: designTokens.textPrimary,
+  textSecondary: designTokens.textBody,
+  textMuted: designTokens.readableMuted,
+  textInverse: designTokens.shellFg,
+  surfaceDefault: designTokens.surface,
+  surfaceElevated: designTokens.surface2,
+  surfaceAccent: designTokens.primaryLight,
+  borderSubtle: designTokens.border,
+  borderStrong: "#CBD5E1",
+  success: designTokens.success,
+  warning: designTokens.warning,
+  danger: designTokens.danger,
+  info: designTokens.primary,
+} as const;

--- a/neufin-web/package.json
+++ b/neufin-web/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "eslint . --ext .ts,.tsx",
     "smoke:staging": "playwright test qa/smoke-staging.spec.ts",
-    "smoke:prod": "playwright test qa/smoke-production.spec.ts"
+    "smoke:prod": "playwright test qa/smoke-production.spec.ts",
+    "test:ui-smoke": "playwright test qa/ui-contrast-smoke.spec.ts"
   },
   "dependencies": {
     "@radix-ui/react-tooltip": "^1.2.8",

--- a/neufin-web/qa/ui-contrast-smoke.spec.ts
+++ b/neufin-web/qa/ui-contrast-smoke.spec.ts
@@ -1,0 +1,28 @@
+/**
+ * Lightweight smoke checks for public routes: layout renders and main landmark exists.
+ * Run: `cd neufin-web && npx playwright test qa/ui-contrast-smoke.spec.ts`
+ * Override base URL: `PLAYWRIGHT_TEST_BASE_URL=http://localhost:3000 npx playwright test ...`
+ */
+import { test, expect } from "@playwright/test";
+
+const PUBLIC_PATHS = [
+  "/",
+  "/pricing",
+  "/features",
+  "/research",
+  "/upload",
+  "/login",
+  "/partners",
+  "/blog",
+] as const;
+
+for (const path of PUBLIC_PATHS) {
+  test(`page renders: ${path}`, async ({ page }) => {
+    const res = await page.goto(path, { waitUntil: "domcontentloaded" });
+    expect(res?.ok(), `${path} HTTP status`).toBeTruthy();
+    const main = page.locator("main").first();
+    await expect(main).toBeVisible({ timeout: 20_000 });
+    const text = await main.innerText();
+    expect(text.length, `${path} main has text`).toBeGreaterThan(20);
+  });
+}

--- a/neufin-web/tailwind.config.ts
+++ b/neufin-web/tailwind.config.ts
@@ -103,6 +103,23 @@ const config: Config = {
           accent: "var(--primary)",
           "accent-soft": "var(--accent-soft)",
         },
+        /** Product UI — readable muted body, shells, inverse text */
+        readable: t.readableMuted,
+        ui: {
+          "text-primary": "var(--ui-text-primary)",
+          "text-secondary": "var(--ui-text-secondary)",
+          muted: "var(--ui-text-muted)",
+          inverse: "var(--ui-text-inverse)",
+          surface: "var(--ui-surface-default)",
+          elevated: "var(--ui-surface-elevated)",
+          accent: "var(--ui-surface-accent)",
+          "border-subtle": "var(--ui-border-subtle)",
+          "border-strong": "var(--ui-border-strong)",
+          success: "var(--status-success)",
+          warning: "var(--status-warning)",
+          danger: "var(--status-danger)",
+          info: "var(--status-info)",
+        },
       },
       borderRadius: {
         sm: "6px",


### PR DESCRIPTION
## Summary
- **Tokens**: `:root` `--ui-*` semantic aliases; Tailwind `ui.*`, `readable`; `uiTokens` in `lib/design-tokens.ts`.
- **BrandLogo**: single component with variants (marketing, app shell, shell-inverted, admin-wordmark, research-footer, etc.); `NeuFinLogo` wraps it for backwards compatibility.
- **Surfaces**: `GlassCard` uses `border-border`; `.card` uses token bg/border; `.text-label` / `.text-caption` use readable muted.
- **Toasts**: success/error styles + icon themes in `RootProviders`.
- **Pages**: dashboard sidebar/nav colors, upload full shell background + CTA/outline-on-dark, research hub nav + search contrast, partners nav links, blog/contact-sales footers, admin shell wordmark + nav hover.
- **QA**: `docs/frontend-ui-audit-checklist.md`, `qa/ui-contrast-smoke.spec.ts`, `npm run test:ui-smoke`.

## Test
- `npm run build` (neufin-web) — passed


Made with [Cursor](https://cursor.com)