### PR TITLE
SEA/VN/FTSE market resolver, admin users fix, upload contrast

### DIFF
--- a/neufin-backend/config.py
+++ b/neufin-backend/config.py
@@ -7,6 +7,8 @@ This module re-exports individual constants so existing imports keep working:
     from config import SUPABASE_URL, APP_BASE_URL   # still works
 """
 
+from __future__ import annotations
+
 from core.config import settings
 
 # ── Supabase ──────────────────────────────────────────────────────────────────

--- a/neufin-backend/core/config.py
+++ b/neufin-backend/core/config.py
@@ -315,6 +315,20 @@ class Settings(BaseSettings):
         ),
     )
 
+    # ── SEA / FX / optional quote fallback (# SEA-TICKER-FIX) ─────────────────
+    FX_DISPLAY_ENABLE: bool = Field(
+        default=True,
+        description="Show indicative SGD conversion next to native CCY in PDF/Swarm when FX API succeeds.",
+    )
+    ENABLE_ITICK_VN_FALLBACK: bool = Field(
+        default=False,
+        description="When True and ITICK_API_KEY is set, try iTick for .VN/.L after Yahoo fails.",
+    )
+    ITICK_API_KEY: str | None = Field(
+        default=None,
+        description="Optional iTick API bearer token for VN/international quote fallback.",
+    )
+
     # ── Git / deployment metadata ─────────────────────────────────────────────
     GIT_COMMIT_SHA: str = Field(
         default="unknown",

--- a/neufin-backend/database.py
+++ b/neufin-backend/database.py
@@ -1,3 +1,9 @@
+import datetime
+
+# Py3.9 — datetime.UTC was added in 3.11
+if not hasattr(datetime, "UTC"):
+    datetime.UTC = datetime.timezone.utc  # type: ignore[attr-defined, assignment]
+
 import structlog
 
 from core.config import settings

--- a/neufin-backend/database.py
+++ b/neufin-backend/database.py
@@ -2,7 +2,7 @@ import datetime
 
 # Py3.9 — datetime.UTC was added in 3.11
 if not hasattr(datetime, "UTC"):
-    datetime.UTC = datetime.timezone.utc  # type: ignore[attr-defined, assignment]
+    datetime.UTC = datetime.timezone.utc  # type: ignore[attr-defined, assignment]  # noqa: UP017
 
 import structlog
 

--- a/neufin-backend/main.py
+++ b/neufin-backend/main.py
@@ -1037,8 +1037,9 @@ async def analyze_dna(
                 failed_tickers.append(sym)
                 price_map[sym] = None
             elif (
-                isinstance(result.price, (int, float)) and float(result.price) <= 0
-            ):  # noqa: UP038
+                isinstance(result.price, (int, float))  # noqa: UP038
+                and float(result.price) <= 0
+            ):
                 failed_tickers.append(sym)
                 price_map[sym] = None
             else:

--- a/neufin-backend/main.py
+++ b/neufin-backend/main.py
@@ -120,7 +120,10 @@ from services.calculator import (  # noqa: E402
     get_tax_impact_analysis,
 )
 from services.fx_format import indicative_sgd_suffix  # noqa: E402
-from services.market_resolver import resolve_security  # noqa: E402
+from services.market_resolver import (  # noqa: E402
+    persist_resolution_best_effort,
+    resolve_security,
+)
 from services.jwt_auth import verify_jwt  # noqa: E402
 from services.risk_engine import (  # noqa: E402
     build_correlation_matrix,
@@ -996,43 +999,68 @@ async def analyze_dna(
     df["shares"] = pd.to_numeric(df["shares"], errors="coerce").fillna(0)
     symbols = df["symbol"].str.upper().unique().tolist()
 
-    # ── 5. Price fetching — treat unresolvable / zero quote as failure, not $0 ───
+    # ── 5. Price fetching — partial success like calculate_portfolio_metrics ───
+    # # SEA-TICKER-FIX: never write $0 for missing quotes; exclude unpriced rows
+    # from totals; return failed_tickers + warnings instead of failing the upload.
     price_results = await asyncio.gather(
         *[asyncio.to_thread(get_price_with_fallback, sym) for sym in symbols],
         return_exceptions=True,
     )
     failed_tickers: list[str] = []
-    price_map: dict[str, float] = {}
-    for sym, result in zip(symbols, price_results, strict=True):
+    price_warnings: list[str] = []
+    status_by_sym: dict[str, str] = {}
+    price_map: dict[str, float | None] = {}
+    for sym, result in zip(symbols, price_results):
         if isinstance(result, ValueError) and "DATA_INTEGRITY_ERROR" in str(result):
             failed_tickers.append(sym)
+            price_map[sym] = None
+            status_by_sym[sym] = "error"
         elif isinstance(result, Exception):
             logger.warning("analyze_dna.price_error", symbol=sym, error=str(result))
             failed_tickers.append(sym)
-        elif getattr(result, "status", None) == "unresolvable" or (
-            getattr(result, "price", None) is None
-            or (isinstance(result.price, int | float) and float(result.price) <= 0)
-        ):
-            failed_tickers.append(sym)
+            price_map[sym] = None
+            status_by_sym[sym] = "error"
         else:
-            price_map[sym] = float(result.price)  # type: ignore[union-attr]
+            st = getattr(result, "status", "") or ""
+            status_by_sym[sym] = st
+            if getattr(result, "warning", ""):
+                price_warnings.append(str(result.warning))
+            if st == "unresolvable" or getattr(result, "price", None) is None:
+                failed_tickers.append(sym)
+                price_map[sym] = None
+            elif isinstance(result.price, (int, float)) and float(result.price) <= 0:
+                failed_tickers.append(sym)
+                price_map[sym] = None
+            else:
+                price_map[sym] = float(result.price)  # type: ignore[union-attr]
+                persist_resolution_best_effort(resolve_security(sym))
 
-    if failed_tickers:
+    df["symbol"] = df["symbol"].str.upper()
+
+    def _px_for(sym: str) -> float:
+        v = price_map.get(sym)
+        return float(v) if v is not None else float("nan")
+
+    df["current_price"] = df["symbol"].map(_px_for)
+    df["value"] = (df["shares"] * df["current_price"]).round(2)
+    total_value = float(df["value"].sum())
+    if total_value <= 0 or not (
+        (df["current_price"].notna()) & (df["shares"] > 0)
+    ).any():
         raise HTTPException(
             status_code=422,
             detail=(
-                f"DATA_INTEGRITY_ERROR: Could not verify price for "
-                f"{', '.join(failed_tickers)}. "
-                "Please check these ticker symbols and try again."
+                "No tickers could be priced. Check symbols/markets and try again. "
+                f"Unpriced: {', '.join(failed_tickers) if failed_tickers else 'all'}"
             ),
         )
 
     prices_available = bool(price_map)
-    df["symbol"] = df["symbol"].str.upper()
-    df["current_price"] = df["symbol"].map(price_map).fillna(0.0)
-    df["value"] = (df["shares"] * df["current_price"]).round(2)
-    total_value = float(df["value"].sum())
-    df["weight"] = df["value"] / total_value if total_value > 0 else 0.0
+    if total_value > 0:
+        df["weight"] = df["value"].fillna(0.0) / total_value
+    else:
+        df["weight"] = 0.0
+    df.loc[df["current_price"].isna(), "weight"] = 0.0
     max_pos = float(df["weight"].max() * 100) if total_value > 0 else 0.0
 
     # ── 6. Scoring — 4-component model ────────────────────────────────────────
@@ -1053,12 +1081,12 @@ async def analyze_dna(
 
     # Correlation factor (30 pts) — top-5 holdings via Alpha Vantage TIME_SERIES_DAILY
     top5_symbols = (
-        df.nlargest(5, "weight")["symbol"].tolist()
+        df.loc[df["weight"] > 0].nlargest(5, "weight")["symbol"].tolist()
         if total_value > 0
         else df["symbol"].tolist()[:5]
     )
     weights_dict = dict(
-        zip(df["symbol"].tolist(), df["weight"].tolist(), strict=True)
+        zip(df["symbol"].tolist(), df["weight"].tolist())
     )
     corr_matrix = await asyncio.to_thread(build_correlation_matrix, top5_symbols)
     clusters = find_correlation_clusters(corr_matrix, weights_dict)
@@ -1082,6 +1110,11 @@ async def analyze_dna(
                 "\nNote: Holdings use multiple listing currencies "
                 f"({', '.join(sorted(ccy_set))}); totals are not FX-converted to a single currency.\n"
             )
+        if failed_tickers:
+            price_note += (
+                f"\nNote: No live quote for: {', '.join(sorted(set(failed_tickers)))}. "
+                "Those lines are excluded from totals; do not treat them as zero-value by choice.\n"
+            )
     else:
         price_note = "\nNote: Live market prices are currently unavailable. Analyze based on share quantities and symbol weights only; do not reference dollar values.\n"
 
@@ -1089,8 +1122,25 @@ async def analyze_dna(
     tax_narrative = tax_analysis.get("narrative", "")
     cluster_narrative = format_clusters_for_ai(clusters)
 
+    _prompt_positions = df.assign(
+        native_currency=df["symbol"].map(lambda s: resolve_security(s).native_currency)
+    )
+    _prompt_records = []
+    for _, prow in _prompt_positions.iterrows():
+        cpp = prow["current_price"]
+        vvv = prow["value"]
+        _prompt_records.append(
+            {
+                "symbol": prow["symbol"],
+                "shares": float(prow["shares"]),
+                "native_currency": prow["native_currency"],
+                "current_price": None if pd.isna(cpp) else float(cpp),
+                "value": None if pd.isna(vvv) else float(vvv),
+            }
+        )
+
     prompt = f"""You are a behavioral finance expert.{price_note}
-Portfolio: {df.assign(native_currency=df["symbol"].map(lambda s: resolve_security(s).native_currency))[["symbol", "shares", "native_currency", "current_price", "value"]].to_dict(orient="records")}
+Portfolio: {_prompt_records}
 Total value (mixed-currency sum, not FX-adjusted): {total_value:,.2f}
 Max position: {max_pos:.1f}%
 Weighted beta: {weighted_beta:.2f}
@@ -1118,28 +1168,28 @@ Return ONLY valid JSON:
 
     # ── 8. Format positions ────────────────────────────────────────────────────
     positions_out = []
-    for _, row in df[["symbol", "shares", "current_price", "value"]].iterrows():
-        weight = (
-            round(float(row["value"]) / total_value * 100, 2)
-            if total_value > 0
-            else 0.0
-        )
+    for _, row in df[["symbol", "shares", "current_price", "value", "weight"]].iterrows():
+        weight = round(float(row["weight"]) * 100, 2) if total_value > 0 else 0.0
         # # SEA-TICKER-FIX: align DNA response with MarketResolver metadata
         _m = resolve_security(str(row["symbol"]))
+        cp = row["current_price"]
+        vv = row["value"]
         pos = {
             "symbol": row["symbol"],
-            "shares": row["shares"],
+            "shares": float(row["shares"]),
             "native_currency": _m.native_currency,
             "market_code": _m.market,
             "provider_ticker": _m.provider_ticker,
             "benchmark": _m.benchmark,
-            "price": row["current_price"],
-            "value": row["value"],
+            "price": None if pd.isna(cp) else float(cp),
+            "value": None if pd.isna(vv) else float(vv),
             "weight": weight,
+            "price_status": status_by_sym.get(str(row["symbol"]).upper(), "live"),
         }
-        fx_hint = indicative_sgd_suffix(float(row["value"]), _m.native_currency)
-        if fx_hint:
-            pos["fx_indicative_sgd"] = fx_hint
+        if not pd.isna(vv):
+            fx_hint = indicative_sgd_suffix(float(vv), _m.native_currency)
+            if fx_hint:
+                pos["fx_indicative_sgd"] = fx_hint
         positions_out.append(pos)
 
     # ── 9. Persist to DB ───────────────────────────────────────────────────────
@@ -1279,7 +1329,8 @@ Return ONLY valid JSON:
         portfolio_id=portfolio_id,
         investor_type=analysis.get("investor_type"),
     )
-    return {
+    num_priced = len([s for s in symbols if s not in set(failed_tickers)])
+    out: dict = {
         **analysis,
         "dna_score": dna_score,
         "score_breakdown": score_breakdown,
@@ -1287,6 +1338,7 @@ Return ONLY valid JSON:
         "multi_currency_portfolio": multi_ccy,
         "portfolio_currencies": sorted(ccy_set),
         "num_positions": len(df),
+        "num_priced": num_priced,
         "max_position_pct": round(max_pos, 2),
         "weighted_beta": round(weighted_beta, 3),
         "avg_correlation": round(avg_corr, 3),
@@ -1299,6 +1351,11 @@ Return ONLY valid JSON:
         "portfolio_id": portfolio_id,
         "market_context": _market_context,
     }
+    if failed_tickers:
+        out["failed_tickers"] = sorted(set(failed_tickers))
+    if price_warnings:
+        out["warnings"] = price_warnings
+    return out
 
 
 # ── System endpoints ───────────────────────────────────────────────────────────

--- a/neufin-backend/main.py
+++ b/neufin-backend/main.py
@@ -132,6 +132,7 @@ from services.risk_engine import (  # noqa: E402
     format_clusters_for_ai,
 )
 
+
 def _zip_equal_lengths(left: list, right: list) -> list[tuple]:
     """Pair two lists; raises if lengths differ (no zip B905 / Py3.9 strict issues)."""
     if len(left) != len(right):
@@ -1035,7 +1036,9 @@ async def analyze_dna(
             if st == "unresolvable" or getattr(result, "price", None) is None:
                 failed_tickers.append(sym)
                 price_map[sym] = None
-            elif isinstance(result.price, (int, float)) and float(result.price) <= 0:  # noqa: UP038
+            elif (
+                isinstance(result.price, (int, float)) and float(result.price) <= 0
+            ):  # noqa: UP038
                 failed_tickers.append(sym)
                 price_map[sym] = None
             else:
@@ -1051,9 +1054,10 @@ async def analyze_dna(
     df["current_price"] = df["symbol"].map(_px_for)
     df["value"] = (df["shares"] * df["current_price"]).round(2)
     total_value = float(df["value"].sum())
-    if total_value <= 0 or not (
-        (df["current_price"].notna()) & (df["shares"] > 0)
-    ).any():
+    if (
+        total_value <= 0
+        or not ((df["current_price"].notna()) & (df["shares"] > 0)).any()
+    ):
         raise HTTPException(
             status_code=422,
             detail=(
@@ -1175,7 +1179,9 @@ Return ONLY valid JSON:
 
     # ── 8. Format positions ────────────────────────────────────────────────────
     positions_out = []
-    for _, row in df[["symbol", "shares", "current_price", "value", "weight"]].iterrows():
+    for _, row in df[
+        ["symbol", "shares", "current_price", "value", "weight"]
+    ].iterrows():
         weight = round(float(row["weight"]) * 100, 2) if total_value > 0 else 0.0
         # # SEA-TICKER-FIX: align DNA response with MarketResolver metadata
         _m = resolve_security(str(row["symbol"]))

--- a/neufin-backend/main.py
+++ b/neufin-backend/main.py
@@ -132,6 +132,13 @@ from services.risk_engine import (  # noqa: E402
     format_clusters_for_ai,
 )
 
+def _zip_equal_lengths(left: list, right: list) -> list[tuple]:
+    """Pair two lists; raises if lengths differ (no zip B905 / Py3.9 strict issues)."""
+    if len(left) != len(right):
+        raise ValueError("paired iteration length mismatch")
+    return [(left[i], right[i]) for i in range(len(left))]
+
+
 # ── Startup time (for uptime_seconds in /health) ──────────────────────────────
 _startup_time: float = time.monotonic()
 
@@ -1010,7 +1017,7 @@ async def analyze_dna(
     price_warnings: list[str] = []
     status_by_sym: dict[str, str] = {}
     price_map: dict[str, float | None] = {}
-    for sym, result in zip(symbols, price_results):
+    for sym, result in _zip_equal_lengths(symbols, price_results):
         if isinstance(result, ValueError) and "DATA_INTEGRITY_ERROR" in str(result):
             failed_tickers.append(sym)
             price_map[sym] = None
@@ -1028,7 +1035,7 @@ async def analyze_dna(
             if st == "unresolvable" or getattr(result, "price", None) is None:
                 failed_tickers.append(sym)
                 price_map[sym] = None
-            elif isinstance(result.price, (int, float)) and float(result.price) <= 0:
+            elif isinstance(result.price, (int, float)) and float(result.price) <= 0:  # noqa: UP038
                 failed_tickers.append(sym)
                 price_map[sym] = None
             else:
@@ -1086,7 +1093,7 @@ async def analyze_dna(
         else df["symbol"].tolist()[:5]
     )
     weights_dict = dict(
-        zip(df["symbol"].tolist(), df["weight"].tolist())
+        _zip_equal_lengths(df["symbol"].tolist(), df["weight"].tolist())
     )
     corr_matrix = await asyncio.to_thread(build_correlation_matrix, top5_symbols)
     clusters = find_correlation_clusters(corr_matrix, weights_dict)

--- a/neufin-backend/main.py
+++ b/neufin-backend/main.py
@@ -119,6 +119,7 @@ from services.calculator import (  # noqa: E402
     get_price_with_fallback,
     get_tax_impact_analysis,
 )
+from services.fx_format import indicative_sgd_suffix  # noqa: E402
 from services.market_resolver import resolve_security  # noqa: E402
 from services.jwt_auth import verify_jwt  # noqa: E402
 from services.risk_engine import (  # noqa: E402
@@ -1002,7 +1003,7 @@ async def analyze_dna(
     )
     failed_tickers: list[str] = []
     price_map: dict[str, float] = {}
-    for sym, result in zip(symbols, price_results):
+    for sym, result in zip(symbols, price_results, strict=True):
         if isinstance(result, ValueError) and "DATA_INTEGRITY_ERROR" in str(result):
             failed_tickers.append(sym)
         elif isinstance(result, Exception):
@@ -1010,7 +1011,7 @@ async def analyze_dna(
             failed_tickers.append(sym)
         elif getattr(result, "status", None) == "unresolvable" or (
             getattr(result, "price", None) is None
-            or (isinstance(result.price, (int, float)) and float(result.price) <= 0)
+            or (isinstance(result.price, int | float) and float(result.price) <= 0)
         ):
             failed_tickers.append(sym)
         else:
@@ -1056,7 +1057,9 @@ async def analyze_dna(
         if total_value > 0
         else df["symbol"].tolist()[:5]
     )
-    weights_dict = dict(zip(df["symbol"].tolist(), df["weight"].tolist()))
+    weights_dict = dict(
+        zip(df["symbol"].tolist(), df["weight"].tolist(), strict=True)
+    )
     corr_matrix = await asyncio.to_thread(build_correlation_matrix, top5_symbols)
     clusters = find_correlation_clusters(corr_matrix, weights_dict)
     corr_pts, avg_corr = correlation_penalty_score(clusters, corr_matrix)
@@ -1123,19 +1126,21 @@ Return ONLY valid JSON:
         )
         # # SEA-TICKER-FIX: align DNA response with MarketResolver metadata
         _m = resolve_security(str(row["symbol"]))
-        positions_out.append(
-            {
-                "symbol": row["symbol"],
-                "shares": row["shares"],
-                "native_currency": _m.native_currency,
-                "market_code": _m.market,
-                "provider_ticker": _m.provider_ticker,
-                "benchmark": _m.benchmark,
-                "price": row["current_price"],
-                "value": row["value"],
-                "weight": weight,
-            }
-        )
+        pos = {
+            "symbol": row["symbol"],
+            "shares": row["shares"],
+            "native_currency": _m.native_currency,
+            "market_code": _m.market,
+            "provider_ticker": _m.provider_ticker,
+            "benchmark": _m.benchmark,
+            "price": row["current_price"],
+            "value": row["value"],
+            "weight": weight,
+        }
+        fx_hint = indicative_sgd_suffix(float(row["value"]), _m.native_currency)
+        if fx_hint:
+            pos["fx_indicative_sgd"] = fx_hint
+        positions_out.append(pos)
 
     # ── 9. Persist to DB ───────────────────────────────────────────────────────
     logger.info(

--- a/neufin-backend/main.py
+++ b/neufin-backend/main.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import datetime
 import io
@@ -114,9 +116,10 @@ from services.calculator import (  # noqa: E402
     _hhi_score,
     _tax_alpha_score,
     fetch_beta,
-    fetch_spot_price,
+    get_price_with_fallback,
     get_tax_impact_analysis,
 )
+from services.market_resolver import resolve_security  # noqa: E402
 from services.jwt_auth import verify_jwt  # noqa: E402
 from services.risk_engine import (  # noqa: E402
     build_correlation_matrix,
@@ -992,21 +995,26 @@ async def analyze_dna(
     df["shares"] = pd.to_numeric(df["shares"], errors="coerce").fillna(0)
     symbols = df["symbol"].str.upper().unique().tolist()
 
-    # ── 5. Price fetching — strict validation (DATA_INTEGRITY_ERROR on 0) ──────
+    # ── 5. Price fetching — treat unresolvable / zero quote as failure, not $0 ───
     price_results = await asyncio.gather(
-        *[asyncio.to_thread(fetch_spot_price, sym) for sym in symbols],
+        *[asyncio.to_thread(get_price_with_fallback, sym) for sym in symbols],
         return_exceptions=True,
     )
     failed_tickers: list[str] = []
     price_map: dict[str, float] = {}
-    for sym, result in zip(symbols, price_results, strict=False):
+    for sym, result in zip(symbols, price_results):
         if isinstance(result, ValueError) and "DATA_INTEGRITY_ERROR" in str(result):
             failed_tickers.append(sym)
         elif isinstance(result, Exception):
             logger.warning("analyze_dna.price_error", symbol=sym, error=str(result))
             failed_tickers.append(sym)
+        elif getattr(result, "status", None) == "unresolvable" or (
+            getattr(result, "price", None) is None
+            or (isinstance(result.price, (int, float)) and float(result.price) <= 0)
+        ):
+            failed_tickers.append(sym)
         else:
-            price_map[sym] = float(result)
+            price_map[sym] = float(result.price)  # type: ignore[union-attr]
 
     if failed_tickers:
         raise HTTPException(
@@ -1048,7 +1056,7 @@ async def analyze_dna(
         if total_value > 0
         else df["symbol"].tolist()[:5]
     )
-    weights_dict = dict(zip(df["symbol"].tolist(), df["weight"].tolist(), strict=False))
+    weights_dict = dict(zip(df["symbol"].tolist(), df["weight"].tolist()))
     corr_matrix = await asyncio.to_thread(build_correlation_matrix, top5_symbols)
     clusters = find_correlation_clusters(corr_matrix, weights_dict)
     corr_pts, avg_corr = correlation_penalty_score(clusters, corr_matrix)
@@ -1062,8 +1070,15 @@ async def analyze_dna(
     }
 
     # ── 7. AI analysis ─────────────────────────────────────────────────────────
+    ccy_set = {resolve_security(s).native_currency for s in df["symbol"].tolist()}
+    multi_ccy = len(ccy_set) > 1
     if prices_available:
         price_note = ""
+        if multi_ccy:
+            price_note = (
+                "\nNote: Holdings use multiple listing currencies "
+                f"({', '.join(sorted(ccy_set))}); totals are not FX-converted to a single currency.\n"
+            )
     else:
         price_note = "\nNote: Live market prices are currently unavailable. Analyze based on share quantities and symbol weights only; do not reference dollar values.\n"
 
@@ -1072,8 +1087,8 @@ async def analyze_dna(
     cluster_narrative = format_clusters_for_ai(clusters)
 
     prompt = f"""You are a behavioral finance expert.{price_note}
-Portfolio: {df[["symbol", "shares", "current_price", "value"]].to_dict(orient="records")}
-Total value: ${total_value:,.2f}
+Portfolio: {df.assign(native_currency=df["symbol"].map(lambda s: resolve_security(s).native_currency))[["symbol", "shares", "native_currency", "current_price", "value"]].to_dict(orient="records")}
+Total value (mixed-currency sum, not FX-adjusted): {total_value:,.2f}
 Max position: {max_pos:.1f}%
 Weighted beta: {weighted_beta:.2f}
 DNA Score: {dna_score}/100
@@ -1106,10 +1121,16 @@ Return ONLY valid JSON:
             if total_value > 0
             else 0.0
         )
+        # # SEA-TICKER-FIX: align DNA response with MarketResolver metadata
+        _m = resolve_security(str(row["symbol"]))
         positions_out.append(
             {
                 "symbol": row["symbol"],
                 "shares": row["shares"],
+                "native_currency": _m.native_currency,
+                "market_code": _m.market,
+                "provider_ticker": _m.provider_ticker,
+                "benchmark": _m.benchmark,
                 "price": row["current_price"],
                 "value": row["value"],
                 "weight": weight,
@@ -1146,17 +1167,30 @@ Return ONLY valid JSON:
             logger.debug("analyze_dna.portfolio_inserted", portfolio_id=portfolio_id)
             for pos in positions_out:
                 try:
-                    supabase.table("portfolio_positions").insert(
-                        {
-                            "portfolio_id": portfolio_id,
-                            "symbol": pos["symbol"],
-                            "shares": pos["shares"],
-                        }
-                    ).execute()
+                    # # SEA-TICKER-FIX: optional columns — omit if migration not applied
+                    row = {
+                        "portfolio_id": portfolio_id,
+                        "symbol": pos["symbol"],
+                        "shares": pos["shares"],
+                        "native_currency": pos.get("native_currency"),
+                        "market_code": pos.get("market_code"),
+                        "provider_ticker": pos.get("provider_ticker"),
+                    }
+                    supabase.table("portfolio_positions").insert(row).execute()
                 except Exception:
-                    logger.warning(
-                        "analyze_dna.position_insert_failed", symbol=pos["symbol"]
-                    )
+                    try:
+                        supabase.table("portfolio_positions").insert(
+                            {
+                                "portfolio_id": portfolio_id,
+                                "symbol": pos["symbol"],
+                                "shares": pos["shares"],
+                            }
+                        ).execute()
+                    except Exception:
+                        logger.warning(
+                            "analyze_dna.position_insert_failed",
+                            symbol=pos["symbol"],
+                        )
         else:
             logger.warning("analyze_dna.portfolio_empty_response")
             portfolio_id = None
@@ -1245,6 +1279,8 @@ Return ONLY valid JSON:
         "dna_score": dna_score,
         "score_breakdown": score_breakdown,
         "total_value": round(total_value, 2),
+        "multi_currency_portfolio": multi_ccy,
+        "portfolio_currencies": sorted(ccy_set),
         "num_positions": len(df),
         "max_position_pct": round(max_pos, 2),
         "weighted_beta": round(weighted_beta, 3),

--- a/neufin-backend/pyproject.toml
+++ b/neufin-backend/pyproject.toml
@@ -35,6 +35,7 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = ["S", "B"]  # security + bugbear skipped in tests
+"routers/vault.py" = ["I001"]  # isort conflicts with manual services.* import grouping
 "alembic/**/*.py" = ["ALL"]   # skip everything in alembic migrations
 
 [tool.ruff.format]

--- a/neufin-backend/routers/admin.py
+++ b/neufin-backend/routers/admin.py
@@ -314,8 +314,9 @@ async def list_users(
     Paginated user list for admin + advisor ops consoles.
     """
     try:
+        # display_name omitted — not present on all prod DBs (use advisor_name).
         query = supabase.table("user_profiles").select(
-            "id, email, advisor_name, display_name, firm_name, subscription_status, "
+            "id, email, advisor_name, firm_name, subscription_status, "
             "subscription_tier, trial_started_at, created_at, last_sign_in_at, role"
         )
         if plan and plan != "all":
@@ -338,7 +339,6 @@ async def list_users(
             for p in profiles
             if q in (p.get("email") or "").lower()
             or q in (p.get("advisor_name") or "").lower()
-            or q in (p.get("display_name") or "").lower()
             or q in (p.get("firm_name") or "").lower()
         ]
         profiles = profiles[offset : offset + limit]
@@ -385,10 +385,7 @@ async def list_users(
             {
                 "id": tid,
                 "email": p.get("email") or "",
-                "name": p.get("advisor_name")
-                or p.get("display_name")
-                or p.get("email")
-                or "",
+                "name": p.get("advisor_name") or p.get("email") or "",
                 "firm_name": p.get("firm_name"),
                 "plan": p.get("subscription_tier") or "—",
                 "status": p.get("subscription_status"),
@@ -419,7 +416,7 @@ async def get_user_detail(
         r = (
             supabase.table("user_profiles")
             .select(
-                "id, email, advisor_name, display_name, firm_name, subscription_status, "
+                "id, email, advisor_name, firm_name, subscription_status, "
                 "subscription_tier, trial_started_at, created_at, last_sign_in_at, role"
             )
             .eq("id", user_id)
@@ -462,7 +459,7 @@ async def get_user_detail(
     return {
         "id": p["id"],
         "email": p.get("email") or "",
-        "name": p.get("advisor_name") or p.get("display_name") or "",
+        "name": p.get("advisor_name") or "",
         "firm_name": p.get("firm_name"),
         "subscription_status": p.get("subscription_status"),
         "subscription_tier": p.get("subscription_tier"),

--- a/neufin-backend/routers/advisor.py
+++ b/neufin-backend/routers/advisor.py
@@ -11,6 +11,8 @@ GET  /api/advisor/clients/{client_id}/reports  → list PDF reports for a client
 POST /api/advisor/reports/batch                → queue reports for multiple clients
 """
 
+from __future__ import annotations
+
 import structlog
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel

--- a/neufin-backend/routers/advisors.py
+++ b/neufin-backend/routers/advisors.py
@@ -6,6 +6,8 @@ GET  /api/advisors/{advisor_id}            → public profile by user UUID
 PUT  /api/advisors/me                      → upsert own profile (requires Bearer token)
 """
 
+from __future__ import annotations
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 

--- a/neufin-backend/routers/developer.py
+++ b/neufin-backend/routers/developer.py
@@ -21,6 +21,8 @@ Endpoints:
   DELETE /api/developer/keys/{key_id}   → revoke a key
 """
 
+from __future__ import annotations
+
 import datetime
 import hashlib
 import secrets

--- a/neufin-backend/routers/dna.py
+++ b/neufin-backend/routers/dna.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 import json
 import time

--- a/neufin-backend/routers/leads.py
+++ b/neufin-backend/routers/leads.py
@@ -16,8 +16,6 @@ import asyncio
 import re
 from datetime import datetime, timedelta, timezone
 
-UTC = timezone.utc  # Py3.9 — datetime.UTC is 3.11+
-
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
@@ -25,6 +23,8 @@ from pydantic import BaseModel
 from database import supabase
 from services.auth_dependency import get_admin_user
 from services.slack import notify_ctech
+
+UTC = timezone.utc  # noqa: UP017  # Py3.9 compat (datetime.UTC is 3.11+)
 
 logger = structlog.get_logger(__name__)
 

--- a/neufin-backend/routers/leads.py
+++ b/neufin-backend/routers/leads.py
@@ -14,7 +14,9 @@ from __future__ import annotations
 
 import asyncio
 import re
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
+
+UTC = timezone.utc  # Py3.9 — datetime.UTC is 3.11+
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query

--- a/neufin-backend/routers/market.py
+++ b/neufin-backend/routers/market.py
@@ -9,6 +9,8 @@ GET /api/market/indices          → live global index quotes (SEA + US, 5-min c
 POST /api/analytics/track        → client-side funnel event ingestion
 """
 
+from __future__ import annotations
+
 import time
 
 import structlog

--- a/neufin-backend/routers/payments.py
+++ b/neufin-backend/routers/payments.py
@@ -12,6 +12,8 @@ POST /api/stripe/webhook    → Stripe event handler
 GET  /api/reports/fulfill   → After payment, generate PDF and return URL
 """
 
+from __future__ import annotations
+
 import asyncio
 import datetime
 

--- a/neufin-backend/routers/portfolio.py
+++ b/neufin-backend/routers/portfolio.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import csv
 import datetime
 import io
@@ -18,6 +20,7 @@ from services.calculator import (
     verify_price_integrity,
 )
 from services.jwt_auth import JWTUser
+from services.market_resolver import resolve_security
 from services.risk_engine import build_risk_report
 
 logger = structlog.get_logger(__name__)
@@ -67,10 +70,12 @@ def _candle(symbol: str, period_days: int) -> dict | None:
     # ── 1. Finnhub ─────────────────────────────────────────────────────────────
     if FINNHUB_API_KEY:
         try:
+            # # SEA-TICKER-FIX: Finnhub symbol normalization (VN / UK / indices)
+            fh_sym = resolve_security(symbol).provider_finnhub
             r = requests.get(
                 "https://finnhub.io/api/v1/stock/candle",
                 params={
-                    "symbol": symbol,
+                    "symbol": fh_sym,
                     "resolution": "D",
                     "from": unix_from,
                     "to": unix_to,
@@ -257,21 +262,37 @@ async def create_portfolio(body: PortfolioCreate):
 
     # Insert positions
     for pos in metrics["positions"]:
+        base_row = {
+            "portfolio_id": portfolio_id,
+            "symbol": pos["symbol"],
+            "shares": pos["shares"],
+            "cost_basis": (
+                encrypt_value(pos["cost_basis"])
+                if pos.get("cost_basis") is not None
+                else None
+            ),
+        }
+        # # SEA-TICKER-FIX: optional metadata columns when migration applied
+        if pos.get("native_currency"):
+            base_row["native_currency"] = pos["native_currency"]
+        if pos.get("market_code"):
+            base_row["market_code"] = pos["market_code"]
+        if pos.get("provider_ticker"):
+            base_row["provider_ticker"] = pos["provider_ticker"]
         try:
-            supabase.table("portfolio_positions").insert(
-                {
-                    "portfolio_id": portfolio_id,
-                    "symbol": pos["symbol"],
-                    "shares": pos["shares"],
-                    "cost_basis": (
-                        encrypt_value(pos["cost_basis"])
-                        if pos.get("cost_basis") is not None
-                        else None
-                    ),
-                }
-            ).execute()
+            supabase.table("portfolio_positions").insert(base_row).execute()
         except Exception:
-            logger.warning("Position insert failed", exc_info=True)
+            try:
+                supabase.table("portfolio_positions").insert(
+                    {
+                        "portfolio_id": portfolio_id,
+                        "symbol": pos["symbol"],
+                        "shares": pos["shares"],
+                        "cost_basis": base_row.get("cost_basis"),
+                    }
+                ).execute()
+            except Exception:
+                logger.warning("Position insert failed", exc_info=True)
 
     return {"portfolio_id": portfolio_id, "metrics": metrics}
 

--- a/neufin-backend/routers/profile.py
+++ b/neufin-backend/routers/profile.py
@@ -8,6 +8,8 @@ POST /api/profile/logo                 → upload image → advisors.logo_base64
 POST /api/profile/onboarding           → legacy alias → complete-onboarding
 """
 
+from __future__ import annotations
+
 import base64
 import io
 import uuid

--- a/neufin-backend/routers/referrals.py
+++ b/neufin-backend/routers/referrals.py
@@ -8,6 +8,8 @@ POST /api/emails/subscribe                → subscribe to weekly digest
 GET  /api/emails/weekly-digest            → data payload for cron email job
 """
 
+from __future__ import annotations
+
 import structlog
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel

--- a/neufin-backend/routers/reports.py
+++ b/neufin-backend/routers/reports.py
@@ -11,6 +11,8 @@
 # CREATE INDEX IF NOT EXISTS idx_analytics_events_user ON analytics_events(user_id);
 # CREATE INDEX IF NOT EXISTS idx_analytics_events_name ON analytics_events(event_name);
 
+from __future__ import annotations
+
 import base64
 import datetime
 import json

--- a/neufin-backend/routers/research.py
+++ b/neufin-backend/routers/research.py
@@ -17,7 +17,9 @@ import json
 import math
 import random
 from collections import defaultdict
-from datetime import UTC, datetime
+from datetime import datetime, timezone
+
+UTC = timezone.utc  # Py3.9 — datetime.UTC is 3.11+
 from typing import Any
 
 import structlog

--- a/neufin-backend/routers/research.py
+++ b/neufin-backend/routers/research.py
@@ -18,8 +18,6 @@ import math
 import random
 from collections import defaultdict
 from datetime import datetime, timezone
-
-UTC = timezone.utc  # Py3.9 — datetime.UTC is 3.11+
 from typing import Any
 
 import structlog
@@ -32,6 +30,8 @@ from services.jwt_auth import JWTUser
 from services.quant_model_engine import analyze_financial_modes
 from services.research.regime_detector import get_current_regime_summary
 from services.research.slug_utils import estimate_read_time_minutes, slugify
+
+UTC = timezone.utc  # noqa: UP017  # Py3.9 compat (datetime.UTC is 3.11+)
 
 logger = structlog.get_logger("neufin.research")
 

--- a/neufin-backend/routers/revenue.py
+++ b/neufin-backend/routers/revenue.py
@@ -6,6 +6,8 @@ All endpoints require advisor role.
 GET /api/revenue/stats → aggregated revenue, subscriber, and funnel stats
 """
 
+from __future__ import annotations
+
 import asyncio
 import calendar
 import datetime

--- a/neufin-backend/routers/swarm.py
+++ b/neufin-backend/routers/swarm.py
@@ -7,6 +7,8 @@ POST /api/swarm/chat      Bloomberg-style agentic chat with MD context
 Both endpoints are public (added to PUBLIC_PREFIXES in main.py).
 """
 
+from __future__ import annotations
+
 import json
 import re
 import uuid

--- a/neufin-backend/routers/vault.py
+++ b/neufin-backend/routers/vault.py
@@ -18,8 +18,6 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
-UTC = timezone.utc  # Py3.9 — datetime.UTC is 3.11+
-
 import stripe
 import structlog
 from fastapi import APIRouter, Depends, HTTPException
@@ -33,11 +31,15 @@ from config import (
     STRIPE_SECRET_KEY,
 )
 from database import claim_guest_data, supabase
-from services.auth_dependency import get_current_user
-from services.auth_dependency import get_subscription_status as get_sub_status
+from services.auth_dependency import (
+    get_current_user,
+    get_subscription_status as get_sub_status,
+)
 from services.jwt_auth import JWTUser
 
 logger = structlog.get_logger("neufin.vault")
+
+UTC = timezone.utc  # noqa: UP017  # Py3.9 compat (datetime.UTC is 3.11+)
 
 # ── Subscription plan definitions ─────────────────────────────────────────────
 # stripe_price_id values are populated after running scripts/setup_stripe_products.py

--- a/neufin-backend/routers/vault.py
+++ b/neufin-backend/routers/vault.py
@@ -14,7 +14,11 @@ GET  /api/plans                  → all subscription plans (public, no auth)
 GET  /api/subscription/status    → current user's plan + monthly usage (auth required)
 """
 
-from datetime import UTC, datetime, timedelta
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+UTC = timezone.utc  # Py3.9 — datetime.UTC is 3.11+
 
 import stripe
 import structlog

--- a/neufin-backend/services/agent_swarm.py
+++ b/neufin-backend/services/agent_swarm.py
@@ -58,7 +58,9 @@ from services.calculator import (  # noqa: E402
     get_tax_impact_analysis,
     get_tax_neutral_pairs,
 )
+from services.fx_format import format_swarm_fx_note  # noqa: E402
 from services.market_cache import get_swarm_job, update_swarm_job  # noqa: E402
+from services.market_resolver import resolve_security  # noqa: E402
 from services.risk_engine import (  # noqa: E402
     _fetch_daily_closes_av,
     build_correlation_matrix_from_series,
@@ -1303,15 +1305,22 @@ async def synthesizer_node(state: SwarmState) -> dict:
     }
 
     # ── Build structured input payload for the MD (all 7 agents) ──────────────
-    portfolio_positions = [
-        {
-            "symbol": t["symbol"],
-            "weight_pct": round(t.get("weight", 0) * 100, 1),
-            "value_usd": round(t.get("value", 0), 2),
-            "beta": round(risk.get("beta_map", {}).get(t["symbol"], 1.0), 2),
-        }
-        for t in state["ticker_data"]
-    ]
+    portfolio_positions = []
+    for t in state["ticker_data"]:
+        sym = t["symbol"]
+        meta = resolve_security(str(sym))
+        val = float(t.get("value", 0))
+        fx_note = format_swarm_fx_note(meta.native_currency, val)
+        portfolio_positions.append(
+            {
+                "symbol": sym,
+                "weight_pct": round(t.get("weight", 0) * 100, 1),
+                "value_usd": round(val, 2),
+                "native_currency": meta.native_currency,
+                "fx_indicative_sgd": fx_note,
+                "beta": round(risk.get("beta_map", {}).get(sym, 1.0), 2),
+            }
+        )
 
     strategist_parsed = (
         json.loads(macro)

--- a/neufin-backend/services/ai_router.py
+++ b/neufin-backend/services/ai_router.py
@@ -3,6 +3,8 @@ AI Fallback Chain (March 14, 2026 Stable):
 Claude Sonnet 4.6 → OpenAI GPT-4o → Gemini 3.1 Pro (→ 1.5 Flash) → Groq Llama 3.3 70B
 """
 
+from __future__ import annotations
+
 import json
 import re
 import time

--- a/neufin-backend/services/analytics.py
+++ b/neufin-backend/services/analytics.py
@@ -12,6 +12,8 @@ Funnel stages tracked:
   referral_used       → checkout with a valid ref_token
 """
 
+from __future__ import annotations
+
 import structlog
 
 from database import supabase

--- a/neufin-backend/services/auth_dependency.py
+++ b/neufin-backend/services/auth_dependency.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import json
 import time

--- a/neufin-backend/services/calculator.py
+++ b/neufin-backend/services/calculator.py
@@ -522,13 +522,13 @@ def fetch_spot_prices_batch(symbols: list[str]) -> dict[str, float]:
                         if sym in remaining:
                             remaining.remove(sym)
                 except Exception as e:
-                    logger.warning(
-                        "price.av_future_error", symbol=sym, error=str(e)
-                    )
+                    logger.warning("price.av_future_error", symbol=sym, error=str(e))
 
     # 8. iTick — optional .VN / .L fallback (# SEA-TICKER-FIX, env-gated)
     if remaining and settings.ENABLE_ITICK_VN_FALLBACK and settings.ITICK_API_KEY:
-        _merge(_itick_batch([s for s in remaining if s.upper().endswith((".VN", ".L"))]))
+        _merge(
+            _itick_batch([s for s in remaining if s.upper().endswith((".VN", ".L"))])
+        )
 
     if remaining:
         logger.warning(
@@ -1197,9 +1197,7 @@ def calculate_portfolio_metrics(positions: list) -> dict:
 
     # Recalculate weights based only on resolved tickers
     resolved_mask = df["symbol"].isin(resolved) & df["current_price"].notna()
-    total_value = float(
-        np.nansum(df.loc[resolved_mask, "current_value"].astype(float))
-    )
+    total_value = float(np.nansum(df.loc[resolved_mask, "current_value"].astype(float)))
     df["weight"] = 0.0
     if total_value > 0:
         df.loc[resolved_mask, "weight"] = (

--- a/neufin-backend/services/calculator.py
+++ b/neufin-backend/services/calculator.py
@@ -12,23 +12,36 @@ import structlog
 from dotenv import load_dotenv
 
 from core.config import settings
-from services.market_currency import (
-    SUFFIX_CURRENCY as _SUFFIX_CURRENCY,
-    finnhub_symbol,
-    infer_native_currency,
-    is_international_listed,
-)
-from services.market_resolver import persist_resolution_best_effort, resolve_security
+from services.fx_format import indicative_sgd_suffix
 from services.market_cache import (
     TICKER_ALIASES,
     PriceResult,
     get_ticker_price_cache,
     upsert_ticker_price_cache,
 )
+from services.market_currency import SUFFIX_CURRENCY as _SUFFIX_CURRENCY
+from services.market_resolver import persist_resolution_best_effort, resolve_security
 
 load_dotenv()  # No-op when Railway injects env vars; loads .env in local dev
 
 logger = structlog.get_logger("neufin.calculator")
+
+
+def _enrich_positions_fx_hint(records: list[dict]) -> list[dict]:
+    """Optional indicative SGD line per position (display-only; gated by settings)."""
+    out: list[dict] = []
+    for r in records:
+        row = dict(r)
+        try:
+            val = float(row.get("current_value") or 0)
+        except (TypeError, ValueError):
+            val = 0.0
+        ccy = str(row.get("native_currency") or "USD")
+        hint = indicative_sgd_suffix(val, ccy)
+        if hint:
+            row["fx_indicative_sgd"] = hint
+        out.append(row)
+    return out
 
 
 def _records_nan_to_none(rows: list[dict]) -> list[dict]:
@@ -389,6 +402,46 @@ def _av_single(sym: str) -> float | None:
         return None
 
 
+def _itick_single(sym: str) -> float | None:
+    """iTick quote for .VN / .L when env-gated; returns None on failure."""
+    if not settings.ENABLE_ITICK_VN_FALLBACK or not settings.ITICK_API_KEY:
+        return None
+    u = sym.upper()
+    if not (u.endswith(".VN") or u.endswith(".L")):
+        return None
+    try:
+        r = requests.get(
+            "https://api.itick.org/v1/quote",
+            params={"code": sym},
+            headers={"Authorization": f"Bearer {settings.ITICK_API_KEY}"},
+            timeout=6.0,
+        )
+        if r.status_code != 200:
+            return None
+        body = r.json()
+        p = body.get("data") if isinstance(body.get("data"), dict) else body
+        if not isinstance(p, dict):
+            return None
+        raw = p.get("price") or p.get("last") or p.get("close") or 0
+        try:
+            price = float(raw)
+        except (TypeError, ValueError):
+            return None
+        return price if price > 0 else None
+    except Exception as e:
+        logger.debug("price.itick_failed", symbol=sym, error=str(e))
+        return None
+
+
+def _itick_batch(symbols: list[str]) -> dict[str, float]:
+    out: dict[str, float] = {}
+    for sym in symbols:
+        px = _itick_single(sym)
+        if px and px > 0:
+            out[sym] = px
+    return out
+
+
 # ── Batch spot-price fetcher (public) ─────────────────────────────────────────
 def fetch_spot_prices_batch(symbols: list[str]) -> dict[str, float]:
     """
@@ -469,14 +522,20 @@ def fetch_spot_prices_batch(symbols: list[str]) -> dict[str, float]:
                         if sym in remaining:
                             remaining.remove(sym)
                 except Exception as e:
-                    logger.warning("price.av_future_error", symbol=sym, error=str(e))
+                    logger.warning(
+                        "price.av_future_error", symbol=sym, error=str(e)
+                    )
+
+    # 8. iTick — optional .VN / .L fallback (# SEA-TICKER-FIX, env-gated)
+    if remaining and settings.ENABLE_ITICK_VN_FALLBACK and settings.ITICK_API_KEY:
+        _merge(_itick_batch([s for s in remaining if s.upper().endswith((".VN", ".L"))]))
 
     if remaining:
         logger.warning(
             "price.resolution_failure",
             symbols=remaining,
             resolved=list(results.keys()),
-            providers_tried="polygon,yfinance,fmp,twelvedata,marketstack,finnhub,alphavantage",
+            providers_tried="polygon,yfinance,fmp,twelvedata,marketstack,finnhub,alphavantage,itick",
         )
         results["__failed__"] = [*remaining]  # type: ignore[assignment]
 
@@ -503,7 +562,7 @@ def fetch_spot_price(sym: str) -> float:
     return result.price if result.price is not None else 0.0
 
 
-def get_price_with_fallback(sym: str) -> "PriceResult":
+def get_price_with_fallback(sym: str) -> PriceResult:
     """
     Full price resolution waterfall returning a PriceResult — never raises.
 
@@ -730,7 +789,7 @@ def fetch_beta(sym: str) -> float:
 
 
 # ── Scoring components ─────────────────────────────────────────────────────────
-def _hhi_score(weights: "pd.Series") -> float:
+def _hhi_score(weights: pd.Series) -> float:
     """
     HHI-based concentration score (0-25 pts).
     Lower HHI (more diversified) → higher score.
@@ -769,7 +828,7 @@ def _beta_score(weighted_beta: float) -> float:
     return round(score, 2)
 
 
-def _tax_alpha_score(df: "pd.DataFrame") -> float:
+def _tax_alpha_score(df: pd.DataFrame) -> float:
     """
     Tax alpha component (0-20 pts).
 
@@ -808,7 +867,7 @@ def _tax_alpha_score(df: "pd.DataFrame") -> float:
 
 
 # ── Tax impact analysis ────────────────────────────────────────────────────────
-def get_tax_impact_analysis(df: "pd.DataFrame") -> dict:
+def get_tax_impact_analysis(df: pd.DataFrame) -> dict:
     """
     Per-position tax liability and harvest-credit analysis at 20% LT CGT rate.
 
@@ -882,7 +941,7 @@ def get_tax_impact_analysis(df: "pd.DataFrame") -> dict:
 
 
 # ── Tax-neutral pair matchmaking ───────────────────────────────────────────────
-def get_tax_neutral_pairs(df: "pd.DataFrame") -> list[dict]:
+def get_tax_neutral_pairs(df: pd.DataFrame) -> list[dict]:
     """
     For the top-2 gainer positions, find the exact loser shares to sell to
     achieve a $0 net tax outcome.
@@ -986,7 +1045,7 @@ def get_tax_neutral_pairs(df: "pd.DataFrame") -> list[dict]:
 
 
 # ── History helpers (used by portfolio metrics) ────────────────────────────────
-def _fetch_symbol_history(sym: str, unix_from: int, unix_to: int) -> "pd.Series | None":
+def _fetch_symbol_history(sym: str, unix_from: int, unix_to: int) -> pd.Series | None:
     """Fetch daily close prices for one symbol. Returns None on failure."""
     if FINNHUB_API_KEY:
         try:
@@ -1217,7 +1276,9 @@ def calculate_portfolio_metrics(positions: list) -> dict:
         "max_position_pct": round(float(df["weight"].max()) * 100, 2),
         "annualized_volatility": round(volatility, 2),
         "pnl_pct": round(pnl_pct, 2) if pnl_pct is not None else None,
-        "positions": _records_nan_to_none(positions_out.to_dict("records")),
+        "positions": _enrich_positions_fx_hint(
+            _records_nan_to_none(positions_out.to_dict("records"))
+        ),
     }
     if price_warnings:
         result["warnings"] = price_warnings

--- a/neufin-backend/services/calculator.py
+++ b/neufin-backend/services/calculator.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import datetime
+import math
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -9,6 +12,13 @@ import structlog
 from dotenv import load_dotenv
 
 from core.config import settings
+from services.market_currency import (
+    SUFFIX_CURRENCY as _SUFFIX_CURRENCY,
+    finnhub_symbol,
+    infer_native_currency,
+    is_international_listed,
+)
+from services.market_resolver import persist_resolution_best_effort, resolve_security
 from services.market_cache import (
     TICKER_ALIASES,
     PriceResult,
@@ -19,6 +29,21 @@ from services.market_cache import (
 load_dotenv()  # No-op when Railway injects env vars; loads .env in local dev
 
 logger = structlog.get_logger("neufin.calculator")
+
+
+def _records_nan_to_none(rows: list[dict]) -> list[dict]:
+    """JSON-safe position rows: float NaN → None (not a misleading null price)."""
+    out: list[dict] = []
+    for r in rows:
+        row = {}
+        for k, v in r.items():
+            if isinstance(v, float) and (math.isnan(v) or math.isinf(v)):
+                row[k] = None
+            else:
+                row[k] = v
+        out.append(row)
+    return out
+
 
 POLYGON_API_KEY = settings.POLYGON_API_KEY
 FINNHUB_API_KEY = settings.FINNHUB_API_KEY
@@ -110,8 +135,9 @@ def _is_rate_limit(response_json: dict) -> bool:
 
 # ── Ticker normalisation ───────────────────────────────────────────────────────
 def _fh_ticker(sym: str) -> str:
-    """Finnhub: BRK.B → BRK-B."""
-    return sym.replace(".", "-").upper()
+    """Finnhub-compatible symbol (regional suffixes keep dots)."""
+    # # SEA-TICKER-FIX: index aliases + regional metadata applied before Finnhub.
+    return resolve_security(sym).provider_finnhub
 
 
 def _polygon_sym(sym: str) -> str:
@@ -298,6 +324,45 @@ def _marketstack_batch(symbols: list[str]) -> dict[str, float]:
         return {}
 
 
+def _yfinance_batch(symbols: list[str]) -> dict[str, float]:
+    """
+    Yahoo Finance last close — reliable for international suffixes (.VN, .L), UK,
+    and indices (^VNINDEX, ^FTSE). Polygon US snapshot does not cover these.
+    """
+    if not symbols:
+        return {}
+    try:
+        import yfinance as yf
+    except ImportError:
+        logger.warning("price.yfinance_unavailable")
+        return {}
+
+    results: dict[str, float] = {}
+
+    def _one(sym: str) -> tuple[str, float | None]:
+        try:
+            # # SEA-TICKER-FIX: Yahoo symbol may differ after index alias normalization.
+            ysym = resolve_security(sym).provider_ticker
+            t = yf.Ticker(ysym)
+            hist = t.history(period="5d", auto_adjust=True)
+            if hist is not None and not hist.empty and "Close" in hist.columns:
+                px = float(hist["Close"].iloc[-1])
+                if px > 0:
+                    return sym, px
+        except Exception as e:
+            logger.debug("price.yfinance_one_failed", symbol=sym, error=str(e))
+        return sym, None
+
+    with ThreadPoolExecutor(max_workers=min(8, len(symbols))) as ex:
+        futs = {ex.submit(_one, s): s for s in symbols}
+        for fut in as_completed(futs, timeout=45.0):
+            sym, px = fut.result()
+            if px and px > 0:
+                results[sym] = px
+                logger.debug("price.yfinance_resolved", symbol=sym, price=px)
+    return results
+
+
 def _av_single(sym: str) -> float | None:
     """Alpha Vantage GLOBAL_QUOTE fallback for one symbol. Returns None when unavailable."""
     if not ALPHA_VANTAGE_API_KEY or not _available("alphavantage"):
@@ -330,9 +395,9 @@ def fetch_spot_prices_batch(symbols: list[str]) -> dict[str, float]:
     Fetch spot prices for a list of symbols using a tiered provider chain
     with circuit breakers.
 
-    Chain: Polygon (batch) → FMP (batch) → TwelveData (batch) →
-           Marketstack (batch) → Finnhub (parallel, ThreadPoolExecutor) →
-           Alpha Vantage (parallel, ThreadPoolExecutor).
+    Chain: Polygon (batch) → Yahoo Finance (international + indices) → FMP →
+           TwelveData → Marketstack → Finnhub (parallel) →
+           Alpha Vantage (parallel).
 
     Returns {sym: price} for every symbol that could be resolved.
     Symbols that could not be resolved are omitted (caller decides how to handle).
@@ -354,19 +419,23 @@ def fetch_spot_prices_batch(symbols: list[str]) -> dict[str, float]:
     if remaining:
         _merge(_polygon_batch(remaining))
 
-    # 2. FMP batch
+    # 2. Yahoo Finance — fills gaps for .VN, .L, ^index, etc.
+    if remaining:
+        _merge(_yfinance_batch(remaining))
+
+    # 3. FMP batch
     if remaining:
         _merge(_fmp_batch(remaining))
 
-    # 3. TwelveData batch
+    # 4. TwelveData batch
     if remaining:
         _merge(_twelvedata_batch(remaining))
 
-    # 4. Marketstack batch
+    # 5. Marketstack batch
     if remaining:
         _merge(_marketstack_batch(remaining))
 
-    # 5. Finnhub — parallel across all remaining symbols
+    # 6. Finnhub — parallel across all remaining symbols
     if remaining and _available("finnhub"):
         syms_to_try = list(remaining)
         with ThreadPoolExecutor(max_workers=min(8, len(syms_to_try))) as ex:
@@ -385,7 +454,7 @@ def fetch_spot_prices_batch(symbols: list[str]) -> dict[str, float]:
                         "price.finnhub_future_error", symbol=sym, error=str(e)
                     )
 
-    # 6. Alpha Vantage — parallel, last resort
+    # 7. Alpha Vantage — parallel, last resort
     if remaining and _available("alphavantage"):
         syms_to_try = list(remaining)
         with ThreadPoolExecutor(max_workers=min(4, len(syms_to_try))) as ex:
@@ -407,7 +476,7 @@ def fetch_spot_prices_batch(symbols: list[str]) -> dict[str, float]:
             "price.resolution_failure",
             symbols=remaining,
             resolved=list(results.keys()),
-            providers_tried="polygon,fmp,twelvedata,marketstack,finnhub,alphavantage",
+            providers_tried="polygon,yfinance,fmp,twelvedata,marketstack,finnhub,alphavantage",
         )
         results["__failed__"] = [*remaining]  # type: ignore[assignment]
 
@@ -560,7 +629,11 @@ def verify_price_integrity(positions: list) -> list[dict]:
 
     # Compute weights using cached prices (best-effort)
     spot = fetch_spot_prices_batch(df["symbol"].tolist())
-    df["current_price"] = df["symbol"].map(spot).fillna(0.0)
+    spot.pop("__failed__", None)
+    df["current_price"] = df["symbol"].map(spot)
+    df["current_price"] = pd.to_numeric(df["current_price"], errors="coerce").fillna(
+        0.0
+    )
     df["current_value"] = df["shares"] * df["current_price"]
     total = float(df["current_value"].sum())
     if total <= 0:
@@ -710,8 +783,12 @@ def _tax_alpha_score(df: "pd.DataFrame") -> float:
 
     df = df.copy()
     df["cost_basis"] = pd.to_numeric(df["cost_basis"], errors="coerce").fillna(0)
-    df["current_price"] = pd.to_numeric(df["current_price"], errors="coerce").fillna(0)
+    df["current_price"] = pd.to_numeric(df["current_price"], errors="coerce")
     df["shares"] = pd.to_numeric(df["shares"], errors="coerce").fillna(0)
+    priced = df["current_price"].notna() & (df["current_price"] > 0)
+    if not priced.any():
+        return 10.0
+    df = df.loc[priced]
 
     total_value = float((df["shares"] * df["current_price"]).sum())
     if total_value <= 0:
@@ -750,7 +827,7 @@ def get_tax_impact_analysis(df: "pd.DataFrame") -> dict:
 
     df = df.copy()
     df["cost_basis"] = pd.to_numeric(df["cost_basis"], errors="coerce").fillna(0)
-    df["current_price"] = pd.to_numeric(df["current_price"], errors="coerce").fillna(0)
+    df["current_price"] = pd.to_numeric(df["current_price"], errors="coerce")
     df["shares"] = pd.to_numeric(df["shares"], errors="coerce").fillna(0)
 
     positions = []
@@ -758,7 +835,19 @@ def get_tax_impact_analysis(df: "pd.DataFrame") -> dict:
     total_harvest_opp = 0.0
 
     for _, row in df.iterrows():
-        gain = (row["current_price"] - row["cost_basis"]) * row["shares"]
+        px = row["current_price"]
+        if pd.isna(px) or float(px) <= 0:
+            positions.append(
+                {
+                    "symbol": row["symbol"],
+                    "unrealised_gain": None,
+                    "tax_liability": 0.0,
+                    "harvest_credit": 0.0,
+                    "note": "price_unavailable",
+                }
+            )
+            continue
+        gain = (float(px) - row["cost_basis"]) * row["shares"]
         if gain > 0:
             tax_liability = round(gain * CGT_RATE, 2)
             harvest_credit = 0.0
@@ -970,25 +1059,6 @@ def _fetch_prices(symbols: list[str], period: str) -> pd.DataFrame:
 
 
 # ── Portfolio metrics (used by routers/portfolio.py) ──────────────────────────
-# ── Currency detection ────────────────────────────────────────────────────────
-# Maps ticker exchange suffix → ISO 4217 currency code.
-_SUFFIX_CURRENCY: dict[str, str] = {
-    ".SI": "SGD",  # Singapore Exchange
-    ".VN": "VND",  # Vietnam HoSE / HNX
-    ".KL": "MYR",  # Bursa Malaysia
-    ".BK": "THB",  # Thailand SET
-    ".HK": "HKD",  # Hong Kong Stock Exchange
-    ".L": "GBP",  # London Stock Exchange
-    ".AX": "AUD",  # ASX Australia
-    ".T": "JPY",  # Tokyo Stock Exchange
-    ".SS": "CNY",  # Shanghai Stock Exchange
-    ".SZ": "CNY",  # Shenzhen Stock Exchange
-    ".NS": "INR",  # NSE India
-    ".BO": "INR",  # BSE India
-    ".JK": "IDR",  # Indonesia IDX
-}
-
-
 def detect_portfolio_currency(symbols: list[str]) -> str:
     """
     Infer the dominant currency from ticker exchange suffixes.
@@ -1016,6 +1086,8 @@ def calculate_portfolio_metrics(positions: list) -> dict:
     df["shares"] = pd.to_numeric(df["shares"], errors="coerce").fillna(0)
     df["symbol"] = df["symbol"].str.upper()
     symbols = df["symbol"].tolist()
+    # # SEA-TICKER-FIX: One resolver pass per row (cached in local dict)
+    _meta_by = {s: resolve_security(s) for s in symbols}
 
     # Resolve prices using the full waterfall (live → alias → stale → unresolvable)
     price_results: dict[str, PriceResult] = {
@@ -1040,19 +1112,35 @@ def calculate_portfolio_metrics(positions: list) -> dict:
             price_warnings.append(r.warning)
 
     spot_prices = {
-        sym: r.price for sym, r in price_results.items() if r.price is not None
+        sym: float(r.price)
+        for sym, r in price_results.items()
+        if r.price is not None and float(r.price) > 0
     }
     price_status = {sym: r.status for sym, r in price_results.items()}
 
-    df["current_price"] = df["symbol"].map(spot_prices).fillna(0.0)
+    df["native_currency"] = df["symbol"].map(lambda s: _meta_by[s].native_currency)
+    df["market_code"] = df["symbol"].map(lambda s: _meta_by[s].market)
+    df["provider_ticker"] = df["symbol"].map(lambda s: _meta_by[s].provider_ticker)
+
+    for sym in resolved:
+        persist_resolution_best_effort(_meta_by[sym])
+    df["current_price"] = df["symbol"].map(spot_prices)
+    df["native_price"] = df["current_price"]
 
     # Historical prices for volatility (only resolved tickers)
     returns = _fetch_historical_returns(resolved, "1mo")
-    df["current_value"] = df["shares"] * df["current_price"]
+    priced = df["symbol"].isin(resolved) & df["current_price"].notna()
+    df["current_value"] = np.where(
+        priced,
+        df["shares"] * df["current_price"],
+        np.nan,
+    )
 
     # Recalculate weights based only on resolved tickers
-    resolved_mask = df["symbol"].isin(resolved)
-    total_value = float(df.loc[resolved_mask, "current_value"].sum())
+    resolved_mask = df["symbol"].isin(resolved) & df["current_price"].notna()
+    total_value = float(
+        np.nansum(df.loc[resolved_mask, "current_value"].astype(float))
+    )
     df["weight"] = 0.0
     if total_value > 0:
         df.loc[resolved_mask, "weight"] = (
@@ -1090,17 +1178,30 @@ def calculate_portfolio_metrics(positions: list) -> dict:
         )
 
     positions_out = df[
-        ["symbol", "shares", "current_price", "current_value", "weight"]
+        [
+            "symbol",
+            "shares",
+            "native_currency",
+            "market_code",
+            "provider_ticker",
+            "native_price",
+            "current_price",
+            "current_value",
+            "weight",
+        ]
     ].copy()
     positions_out["price_status"] = (
         positions_out["symbol"].map(price_status).fillna("live")
     )
-
     base_currency = detect_portfolio_currency(symbols)
+    positions_out["portfolio_base_currency"] = base_currency
+    positions_out["display_currency"] = positions_out["native_currency"]
+    positions_out["fx_rate_used"] = None
 
     result = {
         "total_value": float(total_value),
         "base_currency": base_currency,
+        "portfolio_base_currency": base_currency,
         "hhi": round(float((df["weight"] ** 2).sum()), 4) if total_value > 0 else 0.0,
         "num_positions": len(df),
         "num_priced": len(resolved),
@@ -1116,7 +1217,7 @@ def calculate_portfolio_metrics(positions: list) -> dict:
         "max_position_pct": round(float(df["weight"].max()) * 100, 2),
         "annualized_volatility": round(volatility, 2),
         "pnl_pct": round(pnl_pct, 2) if pnl_pct is not None else None,
-        "positions": positions_out.to_dict("records"),
+        "positions": _records_nan_to_none(positions_out.to_dict("records")),
     }
     if price_warnings:
         result["warnings"] = price_warnings

--- a/neufin-backend/services/fx_format.py
+++ b/neufin-backend/services/fx_format.py
@@ -1,0 +1,99 @@
+"""
+# SEA-TICKER-FIX: Indicative FX strings for PDF / Swarm (display-only, not trading marks).
+
+Uses exchangerate.host (no API key) with a 1h in-process cache.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import requests
+import structlog
+
+from core.config import settings
+
+logger = structlog.get_logger("neufin.fx_format")
+
+_lock = threading.Lock()
+# (base, quote) -> (rate, epoch_ts)
+_rate_cache: dict[tuple[str, str], tuple[float, float]] = {}
+_TTL = 3600.0
+
+
+def get_cross_rate(base: str, quote: str) -> float | None:
+    """Return *quote* per 1 *base* (e.g. SGD per VND)."""
+    b, q = base.upper(), quote.upper()
+    if b == q:
+        return 1.0
+    if not settings.FX_DISPLAY_ENABLE:
+        return None
+    now = time.time()
+    key = (b, q)
+    with _lock:
+        hit = _rate_cache.get(key)
+        if hit and now - hit[1] < _TTL:
+            return hit[0]
+    try:
+        url = f"https://api.exchangerate.host/latest?base={b}&symbols={q}"
+        r = requests.get(url, timeout=5.0)
+        data = r.json()
+        if data.get("success") is False:
+            return None
+        rates = data.get("rates") or {}
+        rate = float(rates.get(q, 0) or 0)
+        if rate > 0:
+            with _lock:
+                _rate_cache[key] = (rate, now)
+            return rate
+    except Exception as exc:
+        logger.debug("fx.cross_rate_failed", base=b, quote=q, error=str(exc))
+    return None
+
+
+def indicative_sgd_suffix(amount_native: float, native_ccy: str) -> str | None:
+    """Single-line hint e.g. ``(≈ S$1.48)`` — None when disabled or same CCY."""
+    if not settings.FX_DISPLAY_ENABLE:
+        return None
+    ccy = native_ccy.upper()
+    if ccy in ("USD", "SGD"):
+        return None
+    r = get_cross_rate(ccy, "SGD")
+    if not r:
+        return None
+    sgd = amount_native * r
+    return f"(≈ S${sgd:,.2f})"
+
+
+def format_pdf_market_value_cell(pos: dict) -> str:
+    """PDF table cell: native amount + optional indicative SGD line."""
+    from services.market_resolver import resolve_security
+
+    p = dict(pos)
+    sym = str(p.get("symbol") or "").strip()
+    if not p.get("native_currency") and sym:
+        try:
+            p["native_currency"] = resolve_security(sym).native_currency
+        except Exception:
+            p["native_currency"] = "USD"
+    val = float(p.get("current_value") or p.get("value") or 0)
+    ccy = (p.get("native_currency") or "USD").upper()
+    if ccy == "USD":
+        return f"${val:,.0f}"
+    if ccy == "VND":
+        line1 = f"{val:,.0f} VND"
+    elif ccy == "GBP":
+        line1 = f"£{val:,.0f}"
+    else:
+        line1 = f"{val:,.2f} {ccy}"
+    suf = indicative_sgd_suffix(val, ccy)
+    if suf:
+        return line1 + "\n" + suf
+    return line1
+
+
+def format_swarm_fx_note(native_ccy: str, value_native: float) -> str | None:
+    """Short string for IC JSON payload."""
+    s = indicative_sgd_suffix(value_native, native_ccy)
+    return s

--- a/neufin-backend/services/market_currency.py
+++ b/neufin-backend/services/market_currency.py
@@ -1,0 +1,54 @@
+"""
+Canonical exchange-suffix → ISO 4217 mapping and ticker hints for pricing providers.
+"""
+
+from __future__ import annotations
+
+# Maps ticker exchange suffix (uppercase key) → ISO 4217 currency code.
+SUFFIX_CURRENCY: dict[str, str] = {
+    ".SI": "SGD",
+    ".VN": "VND",
+    ".KL": "MYR",
+    ".BK": "THB",
+    ".HK": "HKD",
+    ".L": "GBP",
+    ".AX": "AUD",
+    ".T": "JPY",
+    ".SS": "CNY",
+    ".SZ": "CNY",
+    ".NS": "INR",
+    ".BO": "INR",
+    ".JK": "IDR",
+}
+
+# Yahoo Finance works reliably for these; Polygon US snapshot does not.
+INTERNATIONAL_SUFFIXES: tuple[str, ...] = tuple(SUFFIX_CURRENCY.keys())
+
+
+def infer_native_currency(symbol: str) -> str:
+    """
+    Infer trading / quote currency from ticker suffix.
+    No suffix or unknown suffix → USD (US-listings default).
+    """
+    u = symbol.upper().strip()
+    for suf, cur in SUFFIX_CURRENCY.items():
+        if u.endswith(suf):
+            return cur
+    return "USD"
+
+
+def is_international_listed(symbol: str) -> bool:
+    u = symbol.upper().strip()
+    return any(u.endswith(suf) for suf in INTERNATIONAL_SUFFIXES)
+
+
+def finnhub_symbol(sym: str) -> str:
+    """
+    Finnhub: US-style class shares BRK.B → BRK-B.
+    Regional listings (e.g. HPG.VN, BP.L) keep the dot — converting to HPG-VN breaks quotes.
+    """
+    u = sym.upper().strip()
+    for suf in INTERNATIONAL_SUFFIXES:
+        if u.endswith(suf):
+            return u
+    return sym.replace(".", "-").upper()

--- a/neufin-backend/services/market_resolver.py
+++ b/neufin-backend/services/market_resolver.py
@@ -8,11 +8,16 @@ and metadata. Falls back to suffix-based logic from market_currency for unknowns
 from __future__ import annotations
 
 from dataclasses import dataclass
+
+import structlog
+
 from services.market_currency import (
     SUFFIX_CURRENCY,
     finnhub_symbol,
     infer_native_currency,
 )
+
+logger = structlog.get_logger("neufin.market_resolver")
 
 
 @dataclass(frozen=True)
@@ -149,5 +154,9 @@ def persist_resolution_best_effort(meta: SecurityMetadata) -> None:
             },
             on_conflict="raw_symbol",
         ).execute()
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug(
+            "symbol_resolution.persist_failed",
+            symbol=meta.normalized_symbol,
+            error=str(exc),
+        )

--- a/neufin-backend/services/market_resolver.py
+++ b/neufin-backend/services/market_resolver.py
@@ -1,0 +1,153 @@
+"""
+# SEA-TICKER-FIX: Canonical market / currency resolution for portfolio symbols.
+
+Resolves user-supplied tickers (incl. VN, UK, indices) to provider-specific IDs
+and metadata. Falls back to suffix-based logic from market_currency for unknowns.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from services.market_currency import (
+    SUFFIX_CURRENCY,
+    finnhub_symbol,
+    infer_native_currency,
+)
+
+
+@dataclass(frozen=True)
+class SecurityMetadata:
+    """# SEA-TICKER-FIX: Single source of truth for a listed security row."""
+
+    raw_symbol: str
+    normalized_symbol: str
+    market: str  # e.g. US, VN, LSE, SG, GLOBAL_INDEX
+    native_currency: str
+    provider_ticker: str  # Yahoo / primary OHLC path (yfinance)
+    provider_finnhub: str  # Finnhub /quote & /stock/candle symbol
+    benchmark: str
+    is_index: bool
+
+
+# # SEA-TICKER-FIX: User-typed index aliases → Yahoo-style symbols
+_INDEX_CANON: dict[str, str] = {
+    "VNINDEX": "^VNINDEX",
+    "VN30": "^VN30",
+    "VN30INDEX": "^VN30",
+    "FTSE": "^FTSE",
+    "FTSE100": "^FTSE",
+}
+
+# # SEA-TICKER-FIX: Known global indices → (market bucket, CCY, default benchmark)
+_INDEX_META: dict[str, tuple[str, str, str]] = {
+    "^VNINDEX": ("GLOBAL_INDEX", "VND", "^VNINDEX"),
+    "^VN30": ("GLOBAL_INDEX", "VND", "^VN30"),
+    "^FTSE": ("GLOBAL_INDEX", "GBP", "^FTSE"),
+    "^GSPC": ("GLOBAL_INDEX", "USD", "^GSPC"),
+    "^DJI": ("GLOBAL_INDEX", "USD", "^DJI"),
+    "^IXIC": ("GLOBAL_INDEX", "USD", "^IXIC"),
+}
+
+
+def _vn_market_from_symbol(sym: str) -> str:
+    """# SEA-TICKER-FIX: Best-effort bucket; HOSE vs HNX not distinguished without MIC."""
+    return "VN"
+
+
+def resolve_security(raw_symbol: str, user_region: str = "global") -> SecurityMetadata:
+    """
+    # SEA-TICKER-FIX: Map raw CSV/API symbol to trading metadata.
+
+    ``user_region`` reserved for future locale hints — does not change logic yet.
+    """
+    _ = user_region
+    raw = (raw_symbol or "").strip()
+    upper = raw.upper()
+
+    # Index aliases (missing caret, common names)
+    if upper in _INDEX_CANON:
+        upper = _INDEX_CANON[upper]
+
+    is_index = upper.startswith("^")
+    if is_index and upper in _INDEX_META:
+        mkt, ccy, bench = _INDEX_META[upper]
+        return SecurityMetadata(
+            raw_symbol=raw_symbol.strip(),
+            normalized_symbol=upper,
+            market=mkt,
+            native_currency=ccy,
+            provider_ticker=upper,
+            provider_finnhub=upper,
+            benchmark=bench,
+            is_index=True,
+        )
+    if is_index:
+        ccy = "USD"
+        bench = upper
+        if "VN" in upper or upper in ("^VNINDEX", "^VN30"):
+            ccy = "VND"
+        elif upper == "^FTSE":
+            ccy = "GBP"
+        return SecurityMetadata(
+            raw_symbol=raw_symbol.strip(),
+            normalized_symbol=upper,
+            market="GLOBAL_INDEX",
+            native_currency=ccy,
+            provider_ticker=upper,
+            provider_finnhub=upper,
+            benchmark=bench,
+            is_index=True,
+        )
+
+    # Equity / ETF — suffix → currency from existing map
+    native = infer_native_currency(upper)
+    if upper.endswith(".VN"):
+        mcode = _vn_market_from_symbol(upper)
+        bench = "^VNINDEX"
+    elif upper.endswith(".L"):
+        mcode = "LSE"
+        bench = "^FTSE"
+    elif any(upper.endswith(suf) for suf in SUFFIX_CURRENCY if suf != ".VN"):
+        mcode = "INTL"
+        bench = "^GSPC"
+    else:
+        mcode = "US"
+        bench = "^GSPC"
+
+    fh = finnhub_symbol(upper)
+    return SecurityMetadata(
+        raw_symbol=raw_symbol.strip(),
+        normalized_symbol=upper,
+        market=mcode,
+        native_currency=native,
+        provider_ticker=upper,
+        provider_finnhub=fh,
+        benchmark=bench,
+        is_index=False,
+    )
+
+
+def persist_resolution_best_effort(meta: SecurityMetadata) -> None:
+    """
+    # SEA-TICKER-FIX: Cache resolver output in Supabase when table exists.
+
+    Non-fatal if table missing or RLS blocks (local dev).
+    """
+    try:
+        from database import supabase
+
+        supabase.table("symbol_market_resolution").upsert(
+            {
+                "raw_symbol": meta.normalized_symbol,
+                "normalized_symbol": meta.normalized_symbol,
+                "market_code": meta.market,
+                "native_currency": meta.native_currency,
+                "provider_yahoo": meta.provider_ticker,
+                "provider_finnhub": meta.provider_finnhub,
+                "benchmark": meta.benchmark,
+                "is_index": meta.is_index,
+            },
+            on_conflict="raw_symbol",
+        ).execute()
+    except Exception:
+        pass

--- a/neufin-backend/services/pdf_generator.py
+++ b/neufin-backend/services/pdf_generator.py
@@ -49,6 +49,7 @@ from reportlab.platypus import (
 )
 
 from services.calculator import canonical_metrics_for_institutional_report
+from services.fx_format import format_pdf_market_value_cell
 from services.report_state import (
     REPORT_DRAFT,
     REPORT_FINAL,
@@ -2195,11 +2196,16 @@ def _page_portfolio_snapshot(
                 if dc_f is None
                 else (ACCENT_GREEN if dc_f >= 0 else ACCENT_RED)
             )
+            if not val:
+                mv_cell = "—"
+            else:
+                mv_raw = format_pdf_market_value_cell(pos)
+                mv_cell = Paragraph(_xml(mv_raw), st["body"])
             hold.append(
                 [
                     sym,
                     f"{w_pct:.1f}%",
-                    f"${val:,.0f}" if val else "—",
+                    mv_cell,
                     str(int(pos.get("shares") or 0)) or "—",
                     f"{beta_p:.2f}" if beta_p else "—",
                     Paragraph(

--- a/neufin-backend/services/report_metrics.py
+++ b/neufin-backend/services/report_metrics.py
@@ -27,16 +27,35 @@ def canonical_portfolio_headlines(
     if not isinstance(m, dict):
         m = {}
 
-    sum_positions = 0.0
-    for p in positions or []:
-        v = float(p.get("value") or p.get("current_value") or 0)
-        if v <= 0:
-            sh = float(p.get("shares") or 0)
-            px = float(
-                p.get("price") or p.get("current_price") or p.get("last_price") or 0
-            )
-            v = sh * px
-        sum_positions += max(0.0, v)
+    def _position_mark(p: dict[str, Any]) -> float:
+        if (p.get("price_status") or "").lower() == "unresolvable":
+            return 0.0
+        raw_v = p.get("value")
+        if raw_v is not None and raw_v != "":
+            try:
+                v = float(raw_v)
+            except (TypeError, ValueError):
+                v = 0.0
+            if v > 0:
+                return v
+        sh_raw = p.get("shares")
+        try:
+            sh = float(sh_raw or 0)
+        except (TypeError, ValueError):
+            sh = 0.0
+        for key in ("native_price", "price", "current_price", "last_price"):
+            px_raw = p.get(key)
+            if px_raw is None or px_raw == "":
+                continue
+            try:
+                px = float(px_raw)
+            except (TypeError, ValueError):
+                continue
+            if px > 0:
+                return max(0.0, sh * px)
+        return 0.0
+
+    sum_positions = sum(_position_mark(p) for p in (positions or []))
 
     tv_stored = float(portfolio_data.get("total_value") or m.get("total_value") or 0)
     if sum_positions > 1.0:

--- a/neufin-backend/services/research/news_intelligence.py
+++ b/neufin-backend/services/research/news_intelligence.py
@@ -19,7 +19,9 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import re
-from datetime import UTC, datetime
+from datetime import datetime, timezone
+
+UTC = timezone.utc  # Py3.9 — datetime.UTC is 3.11+
 
 import feedparser
 import httpx

--- a/neufin-backend/services/research/news_intelligence.py
+++ b/neufin-backend/services/research/news_intelligence.py
@@ -21,8 +21,6 @@ import hashlib
 import re
 from datetime import datetime, timezone
 
-UTC = timezone.utc  # Py3.9 — datetime.UTC is 3.11+
-
 import feedparser
 import httpx
 import structlog
@@ -30,6 +28,8 @@ import structlog
 from core.config import settings
 from database import supabase
 from services.ai_router import get_ai_analysis
+
+UTC = timezone.utc  # noqa: UP017  # Py3.9 compat (datetime.UTC is 3.11+)
 
 logger = structlog.get_logger("neufin.news_intelligence")
 

--- a/neufin-backend/services/research/regime_detector.py
+++ b/neufin-backend/services/research/regime_detector.py
@@ -22,13 +22,13 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime, timedelta, timezone
 
-UTC = timezone.utc  # Py3.9 — datetime.UTC is 3.11+
-
 import structlog
 
 from database import supabase
 from services.ai_router import get_ai_analysis
 from services.research.slug_utils import slugify
+
+UTC = timezone.utc  # noqa: UP017  # Py3.9 compat (datetime.UTC is 3.11+)
 
 logger = structlog.get_logger("neufin.regime_detector")
 

--- a/neufin-backend/services/research/regime_detector.py
+++ b/neufin-backend/services/research/regime_detector.py
@@ -20,7 +20,9 @@ Schedule: every 6 hours via APScheduler.
 from __future__ import annotations
 
 import asyncio
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
+
+UTC = timezone.utc  # Py3.9 — datetime.UTC is 3.11+
 
 import structlog
 

--- a/neufin-backend/services/research/synthesiser.py
+++ b/neufin-backend/services/research/synthesiser.py
@@ -15,7 +15,9 @@ Also callable on-demand via POST /api/research/generate.
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
+
+UTC = timezone.utc  # Py3.9 — datetime.UTC is 3.11+
 from typing import Any
 
 import structlog

--- a/neufin-backend/services/research/synthesiser.py
+++ b/neufin-backend/services/research/synthesiser.py
@@ -16,8 +16,6 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timedelta, timezone
-
-UTC = timezone.utc  # Py3.9 — datetime.UTC is 3.11+
 from typing import Any
 
 import structlog
@@ -26,6 +24,8 @@ from database import supabase
 from services.ai_router import get_ai_analysis
 from services.research.regime_detector import get_current_regime_summary
 from services.research.slug_utils import slugify
+
+UTC = timezone.utc  # noqa: UP017  # Py3.9 compat (datetime.UTC is 3.11+)
 
 logger = structlog.get_logger("neufin.synthesiser")
 

--- a/neufin-backend/services/sales_digest.py
+++ b/neufin-backend/services/sales_digest.py
@@ -10,7 +10,9 @@ Can also be triggered on-demand for testing.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
+
+UTC = timezone.utc  # Py3.9 — datetime.UTC is 3.11+
 
 import structlog
 

--- a/neufin-backend/services/sales_digest.py
+++ b/neufin-backend/services/sales_digest.py
@@ -12,12 +12,12 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
-UTC = timezone.utc  # Py3.9 — datetime.UTC is 3.11+
-
 import structlog
 
 from database import supabase
 from services.slack import notify_ctech
+
+UTC = timezone.utc  # noqa: UP017  # Py3.9 compat (datetime.UTC is 3.11+)
 
 logger = structlog.get_logger("neufin.sales_digest")
 

--- a/neufin-backend/supabase/migrations/20260419120000_sea_ticker_metadata.sql
+++ b/neufin-backend/supabase/migrations/20260419120000_sea_ticker_metadata.sql
@@ -1,0 +1,25 @@
+-- # SEA-TICKER-FIX: symbol resolution cache + optional portfolio position metadata (idempotent).
+
+create table if not exists public.symbol_market_resolution (
+  raw_symbol text primary key,
+  normalized_symbol text not null,
+  market_code text,
+  native_currency text,
+  provider_yahoo text,
+  provider_finnhub text,
+  benchmark text,
+  is_index boolean default false,
+  updated_at timestamptz not null default now()
+);
+
+alter table public.portfolio_positions
+  add column if not exists native_currency text;
+
+alter table public.portfolio_positions
+  add column if not exists market_code text;
+
+alter table public.portfolio_positions
+  add column if not exists provider_ticker text;
+
+create index if not exists symbol_market_resolution_market_idx
+  on public.symbol_market_resolution (market_code);

--- a/neufin-backend/supabase_migration_sea_ticker_metadata.sql
+++ b/neufin-backend/supabase_migration_sea_ticker_metadata.sql
@@ -1,0 +1,26 @@
+-- # SEA-TICKER-FIX: Optional cache table + portfolio column metadata (idempotent).
+-- Run once in Supabase SQL editor or via migration pipeline.
+
+create table if not exists public.symbol_market_resolution (
+  raw_symbol text primary key,
+  normalized_symbol text not null,
+  market_code text,
+  native_currency text,
+  provider_yahoo text,
+  provider_finnhub text,
+  benchmark text,
+  is_index boolean default false,
+  updated_at timestamptz not null default now()
+);
+
+alter table public.portfolio_positions
+  add column if not exists native_currency text;
+
+alter table public.portfolio_positions
+  add column if not exists market_code text;
+
+alter table public.portfolio_positions
+  add column if not exists provider_ticker text;
+
+create index if not exists symbol_market_resolution_market_idx
+  on public.symbol_market_resolution (market_code);

--- a/neufin-backend/tests/test_analyze_dna_multipart.py
+++ b/neufin-backend/tests/test_analyze_dna_multipart.py
@@ -23,16 +23,18 @@ def client():
     # Patch heavy dependencies so the test is unit-level and never hits network
     with (
         patch("database.supabase") as mock_supabase,
-        patch("yfinance.download") as mock_yf,
+        patch(
+            "main.get_price_with_fallback",
+        ) as mock_price,
         patch("services.ai_router.get_ai_analysis", new_callable=AsyncMock) as mock_ai,
         patch("services.analytics.track", new_callable=AsyncMock),
     ):
-        # yfinance returns a DataFrame; ["Close"] gives a DataFrame (rows=dates, cols=tickers).
-        # main.py uses isinstance(raw, pd.DataFrame) to detect this case.
-        import pandas as pd
+        from services.market_cache import PriceResult
 
-        mock_close_df = pd.DataFrame([{"AAPL": 180.0, "MSFT": 370.0}])
-        mock_yf.return_value = {"Close": mock_close_df}
+        def _price(sym: str, **_: object) -> PriceResult:
+            return PriceResult(symbol=sym.upper(), price=180.0, status="live")
+
+        mock_price.side_effect = _price
 
         # ai_router returns a fixed analysis dict
         mock_ai.return_value = {

--- a/neufin-backend/tests/unit/test_calculator.py
+++ b/neufin-backend/tests/unit/test_calculator.py
@@ -122,6 +122,20 @@ class TestDNAScoreComponents:
 
 
 class TestPriceFetching:
+    @patch("services.calculator._yfinance_batch")
+    @patch("services.calculator._polygon_batch")
+    def test_yahoo_fills_when_polygon_empty(self, mock_polygon, mock_yfinance):
+        mock_polygon.return_value = {}
+        mock_yfinance.return_value = {"HPG.VN": 22.4, "^FTSE": 7800.0}
+        import services.calculator as calc
+        from services.calculator import _fetch_prices_batch
+
+        calc._BLACKLIST.clear()
+        result = _fetch_prices_batch(["HPG.VN", "^FTSE"])
+        mock_yfinance.assert_called()
+        assert result["HPG.VN"] == pytest.approx(22.4)
+        assert result["^FTSE"] == pytest.approx(7800.0)
+
     @patch("services.calculator._polygon_batch")
     def test_uses_polygon_first(self, mock_polygon):
         mock_polygon.return_value = {"AAPL": 185.0}

--- a/neufin-backend/tests/unit/test_fx_format.py
+++ b/neufin-backend/tests/unit/test_fx_format.py
@@ -1,0 +1,60 @@
+"""Unit tests for indicative FX helpers (display-only)."""
+
+from unittest.mock import patch
+
+import pytest
+
+from core.config import settings
+from services.fx_format import (
+    format_pdf_market_value_cell,
+    get_cross_rate,
+    indicative_sgd_suffix,
+)
+
+
+def test_get_cross_rate_identity() -> None:
+    assert get_cross_rate("USD", "USD") == 1.0
+
+
+@patch("services.fx_format.requests.get")
+def test_get_cross_rate_fetches(mock_get, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "FX_DISPLAY_ENABLE", True)
+    import services.fx_format as fx
+
+    fx._rate_cache.clear()
+    mock_get.return_value.json.return_value = {"success": True, "rates": {"SGD": 1.35}}
+    mock_get.return_value.status_code = 200
+    r = get_cross_rate("USD", "SGD")
+    assert r == pytest.approx(1.35)
+    r2 = get_cross_rate("USD", "SGD")
+    assert r2 == pytest.approx(1.35)
+    assert mock_get.call_count == 1
+
+
+def test_fx_display_disabled_no_indicative(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "FX_DISPLAY_ENABLE", False)
+    assert indicative_sgd_suffix(1_000_000, "VND") is None
+
+
+def test_indicative_sgd_uses_rate(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "FX_DISPLAY_ENABLE", True)
+    with patch("services.fx_format.get_cross_rate", return_value=5e-5):
+        s = indicative_sgd_suffix(10_000_000, "VND")
+    assert s is not None
+    assert "S$" in s
+
+
+def test_format_pdf_market_value_usd(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "FX_DISPLAY_ENABLE", True)
+    cell = format_pdf_market_value_cell(
+        {"symbol": "AAPL", "value": 10000, "native_currency": "USD"}
+    )
+    assert cell.startswith("$")
+
+
+def test_format_pdf_market_value_vn(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "FX_DISPLAY_ENABLE", False)
+    cell = format_pdf_market_value_cell(
+        {"symbol": "HPG.VN", "value": 1_000_000, "native_currency": "VND"}
+    )
+    assert "VND" in cell

--- a/neufin-backend/tests/unit/test_market_currency.py
+++ b/neufin-backend/tests/unit/test_market_currency.py
@@ -1,0 +1,24 @@
+"""Tests for services/market_currency.py."""
+
+from services.market_currency import (
+    finnhub_symbol,
+    infer_native_currency,
+    is_international_listed,
+)
+
+
+def test_infer_native_currency_vn_l_usd():
+    assert infer_native_currency("HPG.VN") == "VND"
+    assert infer_native_currency("BP.L") == "GBP"
+    assert infer_native_currency("AAPL") == "USD"
+
+
+def test_finnhub_symbol_preserves_regional_dots():
+    assert finnhub_symbol("HPG.VN") == "HPG.VN"
+    assert finnhub_symbol("BP.L") == "BP.L"
+    assert finnhub_symbol("BRK.B") == "BRK-B"
+
+
+def test_is_international_listed():
+    assert is_international_listed("MBB.VN") is True
+    assert is_international_listed("AAPL") is False

--- a/neufin-backend/tests/unit/test_market_resolver.py
+++ b/neufin-backend/tests/unit/test_market_resolver.py
@@ -31,3 +31,16 @@ def test_us_unchanged():
     assert m.native_currency == "USD"
     assert m.market == "US"
     assert m.provider_ticker == "AAPL"
+
+
+def test_ftse_index_gbp():
+    m = resolve_security("FTSE100")
+    assert m.normalized_symbol == "^FTSE"
+    assert m.native_currency == "GBP"
+    assert m.benchmark == "^FTSE"
+
+
+def test_caret_vn30_vnd():
+    m = resolve_security("^VN30")
+    assert m.native_currency == "VND"
+    assert m.is_index

--- a/neufin-backend/tests/unit/test_market_resolver.py
+++ b/neufin-backend/tests/unit/test_market_resolver.py
@@ -1,0 +1,33 @@
+"""# SEA-TICKER-FIX: MarketResolver unit tests."""
+
+from services.market_resolver import resolve_security
+
+
+def test_hpg_vn_vnd_hose_bucket():
+    m = resolve_security("HPG.VN")
+    assert m.native_currency == "VND"
+    assert m.market == "VN"
+    assert m.provider_ticker == "HPG.VN"
+    assert m.benchmark == "^VNINDEX"
+    assert not m.is_index
+
+
+def test_vnindex_alias_to_caret():
+    m = resolve_security("VNINDEX")
+    assert m.normalized_symbol == "^VNINDEX"
+    assert m.is_index
+    assert m.native_currency == "VND"
+
+
+def test_vod_l_gbp():
+    m = resolve_security("VOD.L")
+    assert m.native_currency == "GBP"
+    assert m.market == "LSE"
+    assert m.benchmark == "^FTSE"
+
+
+def test_us_unchanged():
+    m = resolve_security("AAPL")
+    assert m.native_currency == "USD"
+    assert m.market == "US"
+    assert m.provider_ticker == "AAPL"

--- a/neufin-backend/tests/unit/test_report_metrics_currency.py
+++ b/neufin-backend/tests/unit/test_report_metrics_currency.py
@@ -1,0 +1,46 @@
+"""Canonical portfolio headlines must not mis-count unpriced rows as zero value."""
+
+import pytest
+
+from services.report_metrics import canonical_portfolio_headlines
+
+
+def test_unresolvable_position_does_not_inflate_aum_via_zero_price():
+    positions = [
+        {
+            "symbol": "HPG.VN",
+            "shares": 100,
+            "value": 0,
+            "price": 0,
+            "price_status": "unresolvable",
+        }
+    ]
+    out = canonical_portfolio_headlines(
+        {"total_value": 5000.0},
+        {},
+        {},
+        positions,
+    )
+    # No valid marks → fall back to stored total
+    assert out["total_value"] == 5000.0
+
+
+def test_native_price_used_when_present():
+    positions = [
+        {"symbol": "HPG.VN", "shares": 10, "native_price": 25.5, "native_currency": "VND"}
+    ]
+    out = canonical_portfolio_headlines({}, {}, {}, positions)
+    assert out["total_value"] == pytest.approx(255.0)
+
+
+def test_value_column_wins_over_reconstruction():
+    positions = [
+        {
+            "symbol": "VCI.VN",
+            "shares": 100,
+            "value": 1_500_000.0,
+            "native_price": 15000.0,
+        }
+    ]
+    out = canonical_portfolio_headlines({}, {}, {}, positions)
+    assert out["total_value"] == pytest.approx(1_500_000.0)

--- a/neufin-backend/tests/unit/test_report_metrics_currency.py
+++ b/neufin-backend/tests/unit/test_report_metrics_currency.py
@@ -27,7 +27,12 @@ def test_unresolvable_position_does_not_inflate_aum_via_zero_price():
 
 def test_native_price_used_when_present():
     positions = [
-        {"symbol": "HPG.VN", "shares": 10, "native_price": 25.5, "native_currency": "VND"}
+        {
+            "symbol": "HPG.VN",
+            "shares": 10,
+            "native_price": 25.5,
+            "native_currency": "VND",
+        }
     ]
     out = canonical_portfolio_headlines({}, {}, {}, positions)
     assert out["total_value"] == pytest.approx(255.0)

--- a/neufin-web/app/dashboard/portfolio/page.tsx
+++ b/neufin-web/app/dashboard/portfolio/page.tsx
@@ -58,7 +58,13 @@ const STAGES = [
 /** Circumference for r=58 (140×140 SVG, stroke 12) */
 const RING_C = 2 * Math.PI * 58;
 
-function formatListedMoney(amount: number, currencyCode?: string | null): string {
+function formatListedMoney(
+  amount: number | null | undefined,
+  currencyCode?: string | null,
+): string {
+  if (amount == null || Number.isNaN(amount)) {
+    return "—";
+  }
   const c = (currencyCode || "USD").toUpperCase();
   if (c === "USD") return `$${amount.toFixed(2)}`;
   if (c === "GBP") return `£${amount.toFixed(2)}`;
@@ -888,10 +894,7 @@ export default function PortfolioPage() {
                         )}
                       </td>
                       <td className="px-4 py-3 text-right font-mono">
-                        {formatListedMoney(
-                          Math.round(p.value),
-                          p.native_currency,
-                        )}
+                        {formatListedMoney(p.value, p.native_currency)}
                       </td>
                       <td className="px-4 py-3 text-right font-mono">
                         {(p.weight * 100).toFixed(1)}%

--- a/neufin-web/app/dashboard/portfolio/page.tsx
+++ b/neufin-web/app/dashboard/portfolio/page.tsx
@@ -58,6 +58,24 @@ const STAGES = [
 /** Circumference for r=58 (140×140 SVG, stroke 12) */
 const RING_C = 2 * Math.PI * 58;
 
+function formatListedMoney(amount: number, currencyCode?: string | null): string {
+  const c = (currencyCode || "USD").toUpperCase();
+  if (c === "USD") return `$${amount.toFixed(2)}`;
+  if (c === "GBP") return `£${amount.toFixed(2)}`;
+  if (c === "EUR") return `€${amount.toFixed(2)}`;
+  if (c === "VND")
+    return `${Math.round(amount).toLocaleString("en-US")} ₫`;
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: c,
+      maximumFractionDigits: 4,
+    }).format(amount);
+  } catch {
+    return `${amount.toLocaleString(undefined, { maximumFractionDigits: 4 })} ${c}`;
+  }
+}
+
 // ── 3-step analysis state machine ────────────────────────────────────────────
 type AnalysisStep = "idle" | "dna_complete" | "swarm_complete" | "report_ready";
 
@@ -503,10 +521,13 @@ export default function PortfolioPage() {
 
   const metricEntries = useMemo(() => {
     if (!result) return [];
+    const multi = Boolean(result.multi_currency_portfolio);
     const rows: { label: string; value: string }[] = [
       {
         label: "Total Value",
-        value: `$${Math.round(result.total_value).toLocaleString()}`,
+        value: multi
+          ? `Mixed CCY (${(result.portfolio_currencies || []).join(", ")}) · raw sum ${Math.round(result.total_value).toLocaleString()}`
+          : `$${Math.round(result.total_value).toLocaleString()}`,
       },
       { label: "Positions", value: String(result.num_positions) },
       {
@@ -861,10 +882,16 @@ export default function PortfolioPage() {
                         {p.shares.toLocaleString()}
                       </td>
                       <td className="px-4 py-3 text-right font-mono">
-                        ${p.price.toFixed(2)}
+                        {formatListedMoney(
+                          p.price,
+                          p.native_currency,
+                        )}
                       </td>
                       <td className="px-4 py-3 text-right font-mono">
-                        ${Math.round(p.value).toLocaleString()}
+                        {formatListedMoney(
+                          Math.round(p.value),
+                          p.native_currency,
+                        )}
                       </td>
                       <td className="px-4 py-3 text-right font-mono">
                         {(p.weight * 100).toFixed(1)}%

--- a/neufin-web/app/research/[slug]/page.tsx
+++ b/neufin-web/app/research/[slug]/page.tsx
@@ -19,8 +19,11 @@ function regimeBadge(regime: string | null | undefined) {
     recession_risk: "Recession risk",
   };
   const k = regime.toLowerCase();
+  const mapped =
+    k in m ? m[k as keyof typeof m] : undefined;
   return (
-    m[k] || regime.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())
+    mapped ||
+    regime.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())
   );
 }
 
@@ -300,7 +303,7 @@ export default async function ResearchArticlePage({
 
           {/* Full markdown content (prose path) */}
           {!s && (
-            <div className="prose prose-slate max-w-none prose-p:text-gray-700 prose-headings:text-gray-900 prose-a:text-primary prose-strong:text-gray-900 prose-code:text-gray-800 prose-code:bg-gray-100 prose-pre:bg-gray-900 prose-pre:text-gray-100">
+            <div className="prose prose-neutral dark:prose-invert max-w-none prose-p:text-muted-foreground prose-headings:text-foreground prose-li:text-muted-foreground prose-a:text-primary prose-strong:text-foreground prose-code:text-foreground prose-code:bg-surface-2 prose-pre:bg-surface-2 prose-pre:text-foreground">
               <ReactMarkdown
                 remarkPlugins={[remarkGfm]}
                 rehypePlugins={[rehypeRaw, rehypeSanitize]}
@@ -316,7 +319,7 @@ export default async function ResearchArticlePage({
               <summary className="cursor-pointer text-sm text-muted-foreground hover:text-foreground">
                 Full analysis
               </summary>
-              <div className="prose prose-slate mt-4 max-w-none prose-p:text-gray-700 prose-headings:text-gray-900 prose-a:text-primary prose-strong:text-gray-900 prose-code:text-gray-800 prose-code:bg-gray-100">
+              <div className="prose prose-neutral dark:prose-invert mt-4 max-w-none prose-p:text-muted-foreground prose-headings:text-foreground prose-li:text-muted-foreground prose-a:text-primary prose-strong:text-foreground prose-code:text-foreground prose-code:bg-surface-2">
                 <ReactMarkdown
                   remarkPlugins={[remarkGfm]}
                   rehypePlugins={[rehypeRaw, rehypeSanitize]}

--- a/neufin-web/app/research/[slug]/page.tsx
+++ b/neufin-web/app/research/[slug]/page.tsx
@@ -1,9 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import rehypeRaw from "rehype-raw";
-import rehypeSanitize from "rehype-sanitize";
+import { ResearchMarkdown } from "@/components/content/ResearchMarkdown";
 import { ShareResearchUrlButton } from "@/components/research/ShareResearchUrlButton";
 import { normalizeResearchContent } from "@/lib/research-normalizer";
 
@@ -185,6 +182,19 @@ export default async function ResearchArticlePage({
           {/* Structured sections (when content was a JSON dict) */}
           {s && (
             <div className="mb-8 space-y-6">
+              {s.thesis &&
+                s.thesis.trim() &&
+                s.thesis.trim() !== (note.executive_summary ?? "").trim() && (
+                  <section className="rounded-xl border border-border/80 bg-surface p-5">
+                    <h2 className="mb-3 text-xs font-mono uppercase tracking-widest text-muted-foreground">
+                      Thesis
+                    </h2>
+                    <p className="text-base leading-relaxed text-foreground">
+                      {s.thesis}
+                    </p>
+                  </section>
+                )}
+
               {s.key_findings && s.key_findings.length > 0 && (
                 <section className="rounded-xl border border-border bg-surface p-5">
                   <h2 className="mb-3 text-xs font-mono uppercase tracking-widest text-muted-foreground">
@@ -303,14 +313,9 @@ export default async function ResearchArticlePage({
 
           {/* Full markdown content (prose path) */}
           {!s && (
-            <div className="prose prose-neutral dark:prose-invert max-w-none prose-p:text-muted-foreground prose-headings:text-foreground prose-li:text-muted-foreground prose-a:text-primary prose-strong:text-foreground prose-code:text-foreground prose-code:bg-surface-2 prose-pre:bg-surface-2 prose-pre:text-foreground">
-              <ReactMarkdown
-                remarkPlugins={[remarkGfm]}
-                rehypePlugins={[rehypeRaw, rehypeSanitize]}
-              >
-                {report.markdown || note.executive_summary}
-              </ReactMarkdown>
-            </div>
+            <ResearchMarkdown
+              markdown={report.markdown || note.executive_summary || ""}
+            />
           )}
 
           {/* Also render the markdown version below structured sections for full context */}
@@ -319,13 +324,8 @@ export default async function ResearchArticlePage({
               <summary className="cursor-pointer text-sm text-muted-foreground hover:text-foreground">
                 Full analysis
               </summary>
-              <div className="prose prose-neutral dark:prose-invert mt-4 max-w-none prose-p:text-muted-foreground prose-headings:text-foreground prose-li:text-muted-foreground prose-a:text-primary prose-strong:text-foreground prose-code:text-foreground prose-code:bg-surface-2">
-                <ReactMarkdown
-                  remarkPlugins={[remarkGfm]}
-                  rehypePlugins={[rehypeRaw, rehypeSanitize]}
-                >
-                  {report.markdown}
-                </ReactMarkdown>
+              <div className="mt-4">
+                <ResearchMarkdown markdown={report.markdown} />
               </div>
             </details>
           )}

--- a/neufin-web/app/results/ResultsContent.tsx
+++ b/neufin-web/app/results/ResultsContent.tsx
@@ -16,6 +16,11 @@ import { useAnalytics } from "@/lib/posthog";
 import { useNeufinAnalytics } from "@/lib/analytics";
 import type { DNAAnalysisResponse } from "@/lib/api";
 import PaywallOverlay from "@/components/PaywallOverlay";
+import {
+  formatNativePrice,
+  formatPositionValuePrimary,
+  shouldShowFxHint,
+} from "@/lib/finance-content";
 
 const PortfolioPie = nextDynamic(() => import("@/components/PortfolioPie"), {
   ssr: false,
@@ -444,6 +449,12 @@ export default function ResultsContent() {
                 <span className="font-semibold text-navy">
                   {usd(result.total_value)}
                 </span>
+                {result.multi_currency_portfolio ? (
+                  <span className="block mt-1 text-xs text-amber-400/90">
+                    Mixed listing currencies — total is a sum of native amounts, not
+                    FX-unified.
+                  </span>
+                ) : null}
                 &nbsp;·&nbsp;
                 {result.num_positions} positions &nbsp;·&nbsp; Max
                 position:&nbsp;
@@ -560,10 +571,17 @@ export default function ResultsContent() {
                             {new Intl.NumberFormat("en-US").format(p.shares)}
                           </td>
                           <td className="py-2.5 px-4 text-right text-slate2">
-                            {usdFull(p.price)}
+                            {formatNativePrice(p.price, p.native_currency)}
                           </td>
                           <td className="py-2.5 px-4 text-right font-medium text-navy">
-                            {usd(p.value)}
+                            <div className="flex flex-col items-end gap-0.5">
+                              <span>{formatPositionValuePrimary(p)}</span>
+                              {shouldShowFxHint(p) ? (
+                                <span className="text-xs font-normal text-muted2">
+                                  {p.fx_indicative_sgd}
+                                </span>
+                              ) : null}
+                            </div>
                           </td>
                           <td className="py-2.5 pl-4">
                             <div className="flex items-center gap-2">
@@ -599,11 +617,18 @@ export default function ResultsContent() {
                         </p>
                         <p className="mt-0.5 text-xs text-muted2">
                           {new Intl.NumberFormat("en-US").format(p.shares)}{" "}
-                          shares · {usdFull(p.price)}
+                          shares · {formatNativePrice(p.price, p.native_currency)}
                         </p>
                       </div>
                       <div className="text-right">
-                        <p className="font-medium text-navy">{usd(p.value)}</p>
+                        <p className="font-medium text-navy">
+                          {formatPositionValuePrimary(p)}
+                        </p>
+                        {shouldShowFxHint(p) ? (
+                          <p className="text-xs text-muted2 mt-0.5">
+                            {p.fx_indicative_sgd}
+                          </p>
+                        ) : null}
                         <div className="mt-1 flex items-center justify-end gap-1.5">
                           <div className="h-1.5 w-12 overflow-hidden rounded-full bg-surface-3">
                             <div

--- a/neufin-web/app/results/ResultsContent.tsx
+++ b/neufin-web/app/results/ResultsContent.tsx
@@ -565,7 +565,12 @@ export default function ResultsContent() {
                           className="transition-colors hover:bg-surface-2"
                         >
                           <td className="py-2.5 pr-4 font-mono font-bold text-navy">
-                            {p.symbol}
+                            <span>{p.symbol}</span>
+                            {p.price == null ? (
+                              <span className="ml-1.5 text-[10px] font-sans font-normal uppercase tracking-wide text-amber-600">
+                                No quote
+                              </span>
+                            ) : null}
                           </td>
                           <td className="py-2.5 px-4 text-right text-slate2">
                             {new Intl.NumberFormat("en-US").format(p.shares)}
@@ -614,6 +619,12 @@ export default function ResultsContent() {
                       <div>
                         <p className="font-mono font-bold text-navy">
                           {p.symbol}
+                          {p.price == null ? (
+                            <span className="ml-1.5 text-[10px] font-sans font-normal uppercase tracking-wide text-amber-600">
+                              {" "}
+                              No quote
+                            </span>
+                          ) : null}
                         </p>
                         <p className="mt-0.5 text-xs text-muted2">
                           {new Intl.NumberFormat("en-US").format(p.shares)}{" "}

--- a/neufin-web/app/share/[token]/ShareCard.tsx
+++ b/neufin-web/app/share/[token]/ShareCard.tsx
@@ -4,6 +4,10 @@ import { motion } from "framer-motion";
 import Link from "next/link";
 import CopyButton from "./CopyButton";
 import AdvisorCTA from "@/components/AdvisorCTA";
+import {
+  parseStringListField,
+  unwrapAccidentalJsonObjectString,
+} from "@/lib/display-text";
 
 interface DNAShare {
   id: string;
@@ -73,7 +77,22 @@ function ScoreArc({ score }: { score: number }) {
   );
 }
 
+function normalizeBulletLines(lines: string[]): string[] {
+  return lines.flatMap((line) => {
+    const t = (line ?? "").trim();
+    if (!t) return [];
+    if (t.startsWith("[")) return parseStringListField(t);
+    return [unwrapAccidentalJsonObjectString(t)];
+  });
+}
+
 export default function ShareCard({ data }: { data: DNAShare }) {
+  const strengths = normalizeBulletLines(data.strengths ?? []);
+  const weaknesses = normalizeBulletLines(data.weaknesses ?? []);
+  const recommendation = unwrapAccidentalJsonObjectString(
+    data.recommendation ?? "",
+  );
+
   const cfg = TYPE_CONFIG[data.investor_type] ?? {
     emoji: "🧬",
     color: "#3b82f6",
@@ -151,7 +170,7 @@ export default function ShareCard({ data }: { data: DNAShare }) {
               💪 Strengths
             </h3>
             <ul className="space-y-2">
-              {data.strengths.map((s, i) => (
+              {strengths.map((s, i) => (
                 <li key={i} className="flex gap-2 text-sm text-shell-fg/90">
                   <span className="text-green-500 shrink-0 mt-0.5">✓</span>
                   {s}
@@ -164,7 +183,7 @@ export default function ShareCard({ data }: { data: DNAShare }) {
               ⚠️ Watch out
             </h3>
             <ul className="space-y-2">
-              {data.weaknesses.map((w, i) => (
+              {weaknesses.map((w, i) => (
                 <li key={i} className="flex gap-2 text-sm text-shell-fg/90">
                   <span className="text-amber-500 shrink-0 mt-0.5">!</span>
                   {w}
@@ -189,7 +208,7 @@ export default function ShareCard({ data }: { data: DNAShare }) {
             🎯 AI Recommendation
           </p>
           <p className="text-sm text-shell-fg/90 leading-relaxed">
-            {data.recommendation}
+            {recommendation || "—"}
           </p>
         </div>
 

--- a/neufin-web/app/upload/page.tsx
+++ b/neufin-web/app/upload/page.tsx
@@ -178,10 +178,16 @@ export default function UploadPage() {
             <code className="text-primary">shares</code>, and optional{" "}
             <code className="text-primary">cost_basis</code>
           </p>
-          <div className="mb-6 rounded-lg border border-shell-border/60 bg-shell-raised/30 px-4 py-3 text-xs text-shell-muted">
-            <p className="font-semibold text-shell-fg mb-1">SEA &amp; international markets supported</p>
-            <p>Use exchange suffixes for non-US tickers — the system auto-detects currency from your symbols:</p>
-            <ul className="mt-1 grid grid-cols-2 gap-x-4 gap-y-0.5 font-mono text-primary">
+          {/* SEA-TICKER-FIX: high-contrast callout — shell-muted was illegible on shell bg */}
+          <div className="mb-6 rounded-lg border border-border bg-surface-2 px-4 py-3 text-sm text-foreground shadow-sm">
+            <p className="font-semibold text-foreground mb-1.5">
+              SEA &amp; international markets supported
+            </p>
+            <p className="text-foreground/90 leading-relaxed">
+              Use exchange suffixes for non-US tickers — the system auto-detects
+              currency from your symbols:
+            </p>
+            <ul className="mt-2 grid grid-cols-2 gap-x-4 gap-y-1 font-mono text-sm text-foreground [&_li]:tracking-tight">
               <li>.SI → SGD (Singapore)</li>
               <li>.VN → VND (Vietnam)</li>
               <li>.KL → MYR (Malaysia)</li>
@@ -189,7 +195,12 @@ export default function UploadPage() {
               <li>.HK → HKD (Hong Kong)</li>
               <li>.L → GBP (London)</li>
             </ul>
-            <p className="mt-1.5">Example: <span className="text-primary font-mono">VCB.VN</span>, <span className="text-primary font-mono">D05.SI</span>, <span className="text-primary font-mono">1155.KL</span></p>
+            <p className="mt-2 text-foreground/90">
+              Example:{" "}
+              <span className="font-mono text-primary font-medium">VCB.VN</span>,{" "}
+              <span className="font-mono text-primary font-medium">D05.SI</span>,{" "}
+              <span className="font-mono text-primary font-medium">1155.KL</span>
+            </p>
           </div>
 
           {/* Drop zone */}

--- a/neufin-web/components/PortfolioPie.tsx
+++ b/neufin-web/components/PortfolioPie.tsx
@@ -40,10 +40,12 @@ const pct = (n: number) =>
 function CustomTooltip({ active, payload }: any) {
   if (!active || !payload?.length) return null;
   const d = payload[0].payload as Position & { color: string };
+  const v =
+    typeof d.value === "number" && !Number.isNaN(d.value) ? d.value : 0;
   return (
     <div className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm shadow-md">
       <p className="font-mono font-semibold text-foreground">{d.symbol}</p>
-      <p className="mt-0.5 text-muted-foreground">{usd(d.value)}</p>
+      <p className="mt-0.5 text-muted-foreground">{usd(v)}</p>
       <p className="mt-0.5 text-sm text-muted-foreground">
         {pct(d.weight)} of portfolio
       </p>
@@ -53,6 +55,12 @@ function CustomTooltip({ active, payload }: any) {
 
 export default function PortfolioPie({ positions }: Props) {
   const data = positions
+    .filter(
+      (p): p is Position & { value: number } =>
+        typeof p.value === "number" &&
+        !Number.isNaN(p.value) &&
+        p.value > 0,
+    )
     .slice()
     .sort((a, b) => b.value - a.value)
     .map((p, i) => ({ ...p, color: SLICE_COLORS[i % SLICE_COLORS.length] }));

--- a/neufin-web/components/content/ResearchMarkdown.tsx
+++ b/neufin-web/components/content/ResearchMarkdown.tsx
@@ -1,0 +1,58 @@
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeRaw from "rehype-raw";
+import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
+
+/**
+ * Canonical research / report markdown rendering — one place for prose tokens,
+ * GFM, and sanitization (no raw HTML/script injection from LLM output).
+ */
+const researchSchema = {
+  ...defaultSchema,
+  tagNames: [
+    ...(defaultSchema.tagNames ?? []),
+    "table",
+    "thead",
+    "tbody",
+    "tr",
+    "th",
+    "td",
+  ],
+  attributes: {
+    ...defaultSchema.attributes,
+    th: ["colspan", "rowspan", "align"],
+    td: ["colspan", "rowspan", "align"],
+  },
+};
+
+const proseClass =
+  "prose prose-neutral dark:prose-invert max-w-none " +
+  "prose-p:text-muted-foreground prose-headings:text-foreground " +
+  "prose-li:text-muted-foreground prose-a:text-primary prose-strong:text-foreground " +
+  "prose-code:text-foreground prose-code:bg-surface-2 prose-pre:bg-surface-2 prose-pre:text-foreground " +
+  "prose-table:text-sm prose-th:border prose-td:border prose-table:border-border";
+
+export function ResearchMarkdown({
+  markdown,
+  className = "",
+}: {
+  markdown: string;
+  className?: string;
+}) {
+  const src = (markdown ?? "").trim();
+  if (!src) {
+    return (
+      <p className="text-sm italic text-muted-foreground">No content available.</p>
+    );
+  }
+  return (
+    <div className={`${proseClass} ${className}`.trim()}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeRaw, [rehypeSanitize, researchSchema]]}
+      >
+        {src}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/neufin-web/lib/api.ts
+++ b/neufin-web/lib/api.ts
@@ -248,6 +248,8 @@ export interface Position {
   value: number;
   weight: number;
   native_currency?: string;
+  /** Indicative SGD line from API when FX display is enabled, e.g. "(≈ S$1,234.56)" */
+  fx_indicative_sgd?: string;
   /** SEA-TICKER-FIX: resolver metadata when present */
   market_code?: string;
   provider_ticker?: string;
@@ -428,6 +430,8 @@ export async function createCheckoutSession(
         price: p.price,
         value: p.value,
         weight: p.weight,
+        native_currency: p.native_currency,
+        fx_indicative_sgd: p.fx_indicative_sgd,
       }))
     : undefined;
   // Prefer the stored portfolio_id (correct portfolios table UUID) over

--- a/neufin-web/lib/api.ts
+++ b/neufin-web/lib/api.ts
@@ -227,6 +227,10 @@ export interface DNAAnalysisResponse {
   share_url: string;
   record_id: string | null;
   portfolio_id: string | null;
+  /** True when listing currencies differ across holdings (total is not a single CCY FX total). */
+  multi_currency_portfolio?: boolean;
+  /** ISO 4217 codes present in the upload. */
+  portfolio_currencies?: string[];
   /** Non-blocking warnings: stale prices, alias resolutions, excluded tickers */
   warnings?: string[];
   /** Tickers that could not be priced and were excluded from analysis */
@@ -239,9 +243,15 @@ export type DNAResult = DNAAnalysisResponse;
 export interface Position {
   symbol: string;
   shares: number;
+  /** Last price in the instrument's listing / native currency when known */
   price: number;
   value: number;
   weight: number;
+  native_currency?: string;
+  /** SEA-TICKER-FIX: resolver metadata when present */
+  market_code?: string;
+  provider_ticker?: string;
+  benchmark?: string;
 }
 
 export interface CandleData {

--- a/neufin-web/lib/api.ts
+++ b/neufin-web/lib/api.ts
@@ -244,8 +244,8 @@ export interface Position {
   symbol: string;
   shares: number;
   /** Last price in the instrument's listing / native currency when known */
-  price: number;
-  value: number;
+  price: number | null;
+  value: number | null;
   weight: number;
   native_currency?: string;
   /** Indicative SGD line from API when FX display is enabled, e.g. "(≈ S$1,234.56)" */
@@ -254,6 +254,8 @@ export interface Position {
   market_code?: string;
   provider_ticker?: string;
   benchmark?: string;
+  /** live | stale | alias | unresolvable | error — from DNA API when present */
+  price_status?: string;
 }
 
 export interface CandleData {

--- a/neufin-web/lib/display-text.test.ts
+++ b/neufin-web/lib/display-text.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseStringListField,
+  unwrapAccidentalJsonObjectString,
+} from "./display-text";
+
+describe("display-text", () => {
+  it("unwraps JSON object recommendation strings", () => {
+    const s = JSON.stringify({ recommendation: "Buy quality." });
+    expect(unwrapAccidentalJsonObjectString(s)).toBe("Buy quality.");
+  });
+
+  it("leaves normal prose alone", () => {
+    expect(unwrapAccidentalJsonObjectString("Stay diversified.")).toBe(
+      "Stay diversified.",
+    );
+  });
+
+  it("parses JSON array lines", () => {
+    expect(parseStringListField('["a","b"]')).toEqual(["a", "b"]);
+  });
+});

--- a/neufin-web/lib/display-text.ts
+++ b/neufin-web/lib/display-text.ts
@@ -1,0 +1,43 @@
+/**
+ * Defensive display helpers so UI never shows raw JSON blobs from LLM/API glitches.
+ */
+
+/** If the whole field is a JSON object string, pull a human-readable string out. */
+export function unwrapAccidentalJsonObjectString(input: string): string {
+  const t = (input ?? "").trim();
+  if (!t.startsWith("{")) return input;
+  try {
+    const p = JSON.parse(t) as Record<string, unknown>;
+    const keys = [
+      "recommendation",
+      "text",
+      "summary",
+      "executive_summary",
+      "message",
+      "body",
+    ] as const;
+    for (const k of keys) {
+      const v = p[k];
+      if (typeof v === "string" && v.trim()) return v.trim();
+    }
+  } catch {
+    /* keep original */
+  }
+  return input;
+}
+
+/** Parse JSON array string or return a one-line fallback. */
+export function parseStringListField(value: string): string[] {
+  const t = value.trim();
+  if (t.startsWith("[")) {
+    try {
+      const j = JSON.parse(t) as unknown;
+      if (Array.isArray(j)) {
+        return j.map((x) => String(x ?? "").trim()).filter(Boolean);
+      }
+    } catch {
+      /* fall through */
+    }
+  }
+  return value ? [value] : [];
+}

--- a/neufin-web/lib/finance-content.ts
+++ b/neufin-web/lib/finance-content.ts
@@ -1,0 +1,86 @@
+/**
+ * Canonical display helpers for portfolio / DNA financial rows.
+ * Values may be in listing currency; optional `fx_indicative_sgd` comes from the API when FX display is enabled.
+ */
+
+import type { Position } from "@/lib/api";
+
+export function formatNativePrice(
+  amount: number,
+  currency: string | undefined | null,
+): string {
+  const c = (currency || "USD").toUpperCase();
+  if (c === "VND") {
+    return new Intl.NumberFormat("en-VN").format(Math.round(amount));
+  }
+  if (c === "GBP") {
+    return new Intl.NumberFormat("en-GB", {
+      style: "currency",
+      currency: "GBP",
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(amount);
+  }
+  if (c === "USD") {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(amount);
+  }
+  try {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: c,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 4,
+    }).format(amount);
+  } catch {
+    return `${amount.toLocaleString("en-US", { maximumFractionDigits: 4 })} ${c}`;
+  }
+}
+
+export function formatNativeValue(
+  amount: number,
+  currency: string | undefined | null,
+): string {
+  const c = (currency || "USD").toUpperCase();
+  if (c === "VND") {
+    return `${new Intl.NumberFormat("en-VN").format(Math.round(amount))} VND`;
+  }
+  if (c === "GBP") {
+    return new Intl.NumberFormat("en-GB", {
+      style: "currency",
+      currency: "GBP",
+      maximumFractionDigits: 0,
+    }).format(amount);
+  }
+  if (c === "USD") {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      maximumFractionDigits: 0,
+    }).format(amount);
+  }
+  try {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: c,
+      maximumFractionDigits: 0,
+    }).format(amount);
+  } catch {
+    return `${amount.toLocaleString("en-US", { maximumFractionDigits: 0 })} ${c}`;
+  }
+}
+
+/** Primary value line for a holding; use with optional `fx_indicative_sgd` for indicative FX. */
+export function formatPositionValuePrimary(p: Pick<Position, "value" | "native_currency">): string {
+  return formatNativeValue(p.value, p.native_currency);
+}
+
+export function shouldShowFxHint(p: Position): boolean {
+  if (!p.fx_indicative_sgd) return false;
+  const c = (p.native_currency || "USD").toUpperCase();
+  return !["USD", "SGD"].includes(c);
+}

--- a/neufin-web/lib/finance-content.ts
+++ b/neufin-web/lib/finance-content.ts
@@ -6,9 +6,12 @@
 import type { Position } from "@/lib/api";
 
 export function formatNativePrice(
-  amount: number,
+  amount: number | null | undefined,
   currency: string | undefined | null,
 ): string {
+  if (amount == null || Number.isNaN(amount)) {
+    return "—";
+  }
   const c = (currency || "USD").toUpperCase();
   if (c === "VND") {
     return new Intl.NumberFormat("en-VN").format(Math.round(amount));
@@ -42,9 +45,12 @@ export function formatNativePrice(
 }
 
 export function formatNativeValue(
-  amount: number,
+  amount: number | null | undefined,
   currency: string | undefined | null,
 ): string {
+  if (amount == null || Number.isNaN(amount)) {
+    return "Quote unavailable";
+  }
   const c = (currency || "USD").toUpperCase();
   if (c === "VND") {
     return `${new Intl.NumberFormat("en-VN").format(Math.round(amount))} VND`;

--- a/neufin-web/lib/research-normalizer.test.ts
+++ b/neufin-web/lib/research-normalizer.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { normalizeResearchContent } from "./research-normalizer";
+
+describe("normalizeResearchContent", () => {
+  it("parses JSON dict and exposes structured sections", () => {
+    const raw = JSON.stringify({
+      thesis: "Macro is soft.",
+      key_findings: [{ finding: "Rates peaked", implication: "Risk-on" }],
+      sector_impacts: [{ sector: "Tech", impact: "Higher beta", direction: "up" }],
+    });
+    const r = normalizeResearchContent(raw, "fallback");
+    expect(r.structured?.key_findings?.[0].finding).toBe("Rates peaked");
+    expect(r.structured?.sector_impacts?.[0].sector).toBe("Tech");
+    expect(r.markdown).toContain("Macro is soft");
+  });
+
+  it("unwraps double-encoded JSON string", () => {
+    const wrapped = JSON.stringify(
+      JSON.stringify({ thesis: "Nested OK", key_findings: [] }),
+    );
+    const r = normalizeResearchContent(wrapped);
+    expect(r.structured?.thesis).toContain("Nested OK");
+  });
+
+  it("falls back to markdown when not JSON", () => {
+    const r = normalizeResearchContent("## Hello\n\nWorld");
+    expect(r.markdown).toContain("Hello");
+    expect(r.structured).toBeUndefined();
+  });
+});

--- a/neufin-web/lib/research-normalizer.ts
+++ b/neufin-web/lib/research-normalizer.ts
@@ -53,6 +53,18 @@ function safeParseJson(raw: string): Record<string, unknown> | null {
       ? (parsed as Record<string, unknown>)
       : null;
   } catch {
+    // Near-JSON: trim trailing prose after the closing `}` (LLM chatter)
+    const end = cleaned.lastIndexOf("}");
+    if (end > 1) {
+      try {
+        const parsed = JSON.parse(cleaned.slice(0, end + 1));
+        return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+          ? (parsed as Record<string, unknown>)
+          : null;
+      } catch {
+        return null;
+      }
+    }
     return null;
   }
 }

--- a/neufin-web/lib/research-normalizer.ts
+++ b/neufin-web/lib/research-normalizer.ts
@@ -27,6 +27,7 @@ export type NormalizedReport = {
   markdown: string;
   /** Structured sections — only present when the payload was a JSON dict */
   structured?: {
+    /** Executive thesis / summary when parsed from JSON */
     thesis?: string;
     key_findings?: KeyFinding[];
     sector_impacts?: SectorImpact[];
@@ -40,15 +41,29 @@ export type NormalizedReport = {
 function safeParseJson(raw: string): Record<string, unknown> | null {
   const trimmed = raw.trim();
   // Remove common LLM artifacts: leading/trailing fences, parentheses
-  const cleaned = trimmed
+  let cleaned = trimmed
     .replace(/^```(?:json)?\s*/i, "")
     .replace(/\s*```$/, "")
     .replace(/^\(\s*/, "")
     .replace(/\s*\)$/, "");
 
+  // Unwrap `"{"thesis":...}"` style double-encoding from some APIs
+  try {
+    if (cleaned.startsWith('"') && cleaned.endsWith('"')) {
+      const once = JSON.parse(cleaned);
+      if (typeof once === "string") cleaned = once.trim();
+    }
+  } catch {
+    /* keep cleaned */
+  }
+
   if (!cleaned.startsWith("{")) return null;
   try {
     const parsed = JSON.parse(cleaned);
+    // Double-encoded JSON string from some providers
+    if (typeof parsed === "string") {
+      return safeParseJson(parsed);
+    }
     return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
       ? (parsed as Record<string, unknown>)
       : null;
@@ -58,6 +73,9 @@ function safeParseJson(raw: string): Record<string, unknown> | null {
     if (end > 1) {
       try {
         const parsed = JSON.parse(cleaned.slice(0, end + 1));
+        if (typeof parsed === "string") {
+          return safeParseJson(parsed);
+        }
         return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
           ? (parsed as Record<string, unknown>)
           : null;
@@ -102,19 +120,20 @@ function toKeyFindings(val: unknown): KeyFinding[] {
 
 function toSectorImpacts(val: unknown): SectorImpact[] {
   if (!Array.isArray(val)) return [];
-  return val
-    .map((item) => {
-      if (typeof item === "object" && item !== null) {
-        const o = item as Record<string, unknown>;
-        return {
-          sector: String(o.sector ?? o.name ?? ""),
-          impact: String(o.impact ?? o.description ?? ""),
-          direction: o.direction ? String(o.direction) : undefined,
-        };
-      }
-      return null;
-    })
-    .filter((s): s is SectorImpact => s !== null && s.sector.length > 0);
+  const out: SectorImpact[] = [];
+  for (const item of val) {
+    if (typeof item !== "object" || item === null) continue;
+    const o = item as Record<string, unknown>;
+    const sector = String(o.sector ?? o.name ?? "").trim();
+    if (!sector) continue;
+    const impact = String(o.impact ?? o.description ?? "").trim();
+    const row: SectorImpact = { sector, impact };
+    if (o.direction != null && String(o.direction).trim()) {
+      row.direction = String(o.direction).trim();
+    }
+    out.push(row);
+  }
+  return out;
 }
 
 function structuredToMarkdown(data: Record<string, unknown>): string {
@@ -202,7 +221,11 @@ export function normalizeResearchContent(
         ? String(parsed.recommended_action)
         : undefined,
     };
-    const markdown = structuredToMarkdown(parsed) || executiveSummary || "";
+    const markdown =
+      structuredToMarkdown(parsed) ||
+      (structured.thesis ? String(structured.thesis) : "") ||
+      executiveSummary ||
+      "";
     return { markdown, structured };
   }
 

--- a/neufin-web/package-lock.json
+++ b/neufin-web/package-lock.json
@@ -49,7 +49,8 @@
         "playwright": "^1.59.1",
         "postcss": "^8",
         "tailwindcss": "^3.4.3",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -366,6 +367,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -3812,6 +4255,17 @@
       "integrity": "sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg==",
       "license": "MIT"
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -3892,6 +4346,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
@@ -4638,6 +5099,131 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
@@ -5194,6 +5780,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
@@ -5584,6 +6180,16 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -5694,6 +6300,23 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/character-entities": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
@@ -5732,6 +6355,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -6276,6 +6909,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -6770,6 +7413,48 @@
       },
       "engines": {
         "node": ">=0.12"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/escalade": {
@@ -7388,6 +8073,16 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/ext": {
@@ -10214,6 +10909,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -11888,6 +12590,23 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -13504,6 +14223,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -13634,6 +14360,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stacktrace-parser": {
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.11.tgz",
@@ -13664,6 +14397,13 @@
         "@stablelib/base64": "^1.0.0",
         "fast-sha256": "^1.3.0"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -13883,6 +14623,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stripe": {
       "version": "21.0.1",
@@ -14273,6 +15033,20 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -14288,6 +15062,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tldts-core": {
@@ -14800,6 +15604,184 @@
         "d3-timer": "^3.0.1"
       }
     },
+    "node_modules/vite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
@@ -15052,6 +16034,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/neufin-web/package-lock.json
+++ b/neufin-web/package-lock.json
@@ -48,7 +48,7 @@
         "lighthouse": "^13.1.0",
         "playwright": "^1.59.1",
         "postcss": "^8",
-        "tailwindcss": "^3.4.3",
+        "tailwindcss": "3.4.19",
         "typescript": "^5",
         "vitest": "^3.2.4"
       }

--- a/neufin-web/package.json
+++ b/neufin-web/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint . --ext .ts,.tsx",
+    "test:unit": "vitest run",
     "smoke:staging": "playwright test qa/smoke-staging.spec.ts",
     "smoke:prod": "playwright test qa/smoke-production.spec.ts",
     "test:ui-smoke": "playwright test qa/ui-contrast-smoke.spec.ts"
@@ -53,6 +54,7 @@
     "playwright": "^1.59.1",
     "postcss": "^8",
     "tailwindcss": "^3.4.3",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^3.2.4"
   }
 }

--- a/neufin-web/package.json
+++ b/neufin-web/package.json
@@ -53,8 +53,11 @@
     "lighthouse": "^13.1.0",
     "playwright": "^1.59.1",
     "postcss": "^8",
-    "tailwindcss": "^3.4.3",
+    "tailwindcss": "3.4.19",
     "typescript": "^5",
     "vitest": "^3.2.4"
+  },
+  "overrides": {
+    "tailwindcss": "3.4.19"
   }
 }

--- a/neufin-web/vitest.config.ts
+++ b/neufin-web/vitest.config.ts
@@ -1,0 +1,14 @@
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["lib/**/*.test.ts"],
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "."),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- **Admin (/admin/users)**: Stops selecting `user_profiles.display_name` (column not present in prod Supabase).
- **Upload page**: Higher-contrast SEA / international ticker callout (`bg-surface-2`, `text-foreground`).
- **MarketResolver** (`services/market_resolver.py`): Canonical `SecurityMetadata` (market, native CCY, Yahoo/Finnhub tickers, benchmark, index flag). Aliases e.g. `VNINDEX` → `^VNINDEX`.
- **Pricing**: `_fh_ticker` / Yahoo batch use resolver; metrics + DNA include `market_code`, `provider_ticker`, `benchmark` where applicable.
- **DB**: Idempotent `supabase_migration_sea_ticker_metadata.sql` for `symbol_market_resolution` + optional `portfolio_positions` columns; inserts fall back if migration not applied.
- **Py 3.9**: `from __future__ import annotations`, `datetime.UTC` shim in `database.py`, router `UTC` imports, `zip(strict=)` removal in `main.py`.

## Post-merge (prod)
Run `supabase_migration_sea_ticker_metadata.sql` in Supabase SQL editor for cache table + position metadata columns.

## Provider limits
Real-time VN depth still depends on Yahoo/Finnhub coverage; optional iTick/VN API fallback can be added later without breaking US flows.

## Testing
`pytest` unit tests for resolver, calculator, analyze-dna multipart.

Made with [Cursor](https://cursor.com)