### PR TITLE
feat(admin): Ops control tower — API + /admin/ops console

### DIFF
--- a/neufin-backend/core/config.py
+++ b/neufin-backend/core/config.py
@@ -335,6 +335,38 @@ class Settings(BaseSettings):
         description="Git commit SHA injected at build time via Railway environment variable.",
     )
 
+    # ── Admin control tower (optional — no secrets in client) ─────────────────
+    OPS_GITHUB_TOKEN: str | None = Field(
+        default=None,
+        description="GitHub PAT for repo intelligence (repo read scope).",
+    )
+    OPS_GITHUB_REPO: str = Field(
+        default="stealthg0dd/neufin",
+        description="owner/repo for GitHub REST stats.",
+    )
+    OPS_VERCEL_TOKEN: str | None = Field(
+        default=None,
+        description="Vercel API token for deployment list (optional).",
+    )
+    OPS_VERCEL_TEAM_ID: str | None = Field(
+        default=None,
+        description="Vercel team ID when project is under a team.",
+    )
+    OPS_VERCEL_PROJECT_ID: str | None = Field(
+        default=None,
+        description="Vercel project ID for /v6/deployments queries.",
+    )
+    OPS_RAILWAY_TOKEN: str | None = Field(
+        default=None,
+        description="Railway API token — reserved for future deploy/health adapters.",
+    )
+    OPS_CONTROL_TOWER_MANUAL_JSON: str | None = Field(
+        default=None,
+        description=(
+            "Optional JSON merged into GET /api/admin/control-tower (ai_accounts, github overrides, etc.)."
+        ),
+    )
+
     # ── Derived helpers ───────────────────────────────────────────────────────
     @property
     def allowed_origins_list(self) -> list[str]:

--- a/neufin-backend/routers/admin.py
+++ b/neufin-backend/routers/admin.py
@@ -19,6 +19,7 @@ Admin only (is_admin):
   GET  /api/admin/reports
   GET  /api/admin/system
   GET  /api/admin/partners/{partner_id}/usage
+  GET  /api/admin/control-tower
 """
 
 from __future__ import annotations
@@ -43,6 +44,7 @@ from services.auth_dependency import (
     invalidate_subscription_cache,
 )
 from services.jwt_auth import JWTUser
+from services.ops_control_tower import get_control_tower_snapshot_cached
 from services.request_metrics import http_stats_last_hours
 
 logger = structlog.get_logger(__name__)
@@ -159,6 +161,12 @@ def _delta_pct(current: float, previous: float) -> float | None:
 @router.get("/api/admin/access")
 async def admin_access(_user: JWTUser = Depends(get_admin_user)):
     return {"ok": True}
+
+
+@router.get("/api/admin/control-tower")
+async def admin_control_tower(_user: JWTUser = Depends(get_admin_user)):
+    """Aggregated ops snapshot: AI usage, GitHub, deploys, errors (admin JWT)."""
+    return await get_control_tower_snapshot_cached()
 
 
 @router.get("/api/admin/dashboard")

--- a/neufin-backend/services/ops_control_tower.py
+++ b/neufin-backend/services/ops_control_tower.py
@@ -1,0 +1,561 @@
+"""
+NeuFin Admin Control Tower — aggregated observability for ops (admin JWT only).
+
+Design:
+- Normalized Pydantic-friendly dicts for AI usage accounts, GitHub, deploys, errors.
+- Adapters are explicit about sync method; nothing is fake-automated.
+- Optional external calls: GitHub REST, OpenAI billing (best-effort), Vercel, Railway.
+- Manual / import overrides via OPS_CONTROL_TOWER_MANUAL_JSON (JSON object).
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import time
+from typing import Any
+
+import httpx
+import structlog
+from pydantic import BaseModel, Field
+
+from core.config import settings
+from services.request_metrics import http_stats_last_hours
+
+logger = structlog.get_logger(__name__)
+
+_CACHE: dict[str, Any] | None = None
+_CACHE_AT: float = 0.0
+_CACHE_TTL = 60.0
+
+
+class SyncSourceType:
+    DIRECT_API = "direct_api"
+    EXPORT_IMPORT = "export_import"
+    MANUAL_OVERRIDE = "manual_override"
+    DASHBOARD_PLACEHOLDER = "dashboard_placeholder"
+
+
+def _utcnow_iso() -> str:
+    return datetime.datetime.now(datetime.UTC).isoformat()
+
+
+def _safe_json_loads(raw: str | None) -> dict[str, Any] | None:
+    if not raw or not str(raw).strip():
+        return None
+    try:
+        return json.loads(raw)
+    except Exception as exc:
+        logger.warning("ops_control_tower.manual_json_invalid", error=str(exc))
+        return None
+
+
+# ── AI usage account (normalized) ─────────────────────────────────────────────
+
+
+class AIUsageAccount(BaseModel):
+    provider_name: str
+    account_name: str
+    workspace_or_org: str | None = None
+    model_name: str | None = None
+    billing_cycle_start: str | None = None
+    billing_cycle_end: str | None = None
+    quota_type: str = "unknown"
+    quota_limit: float | None = None
+    quota_used: float | None = None
+    quota_remaining: float | None = None
+    cost_to_date_usd: float | None = None
+    estimated_runway_days: float | None = None
+    refresh_source: str
+    last_synced_at: str | None = None
+    sync_confidence: float = Field(
+        ge=0.0,
+        le=1.0,
+        description="1.0 = verified API read; 0 = manual stub",
+    )
+    notes: str | None = None
+
+
+def _manual_accounts_from_env() -> list[AIUsageAccount]:
+    """Optional OPS_CONTROL_TOWER_MANUAL_JSON key `ai_accounts` list."""
+    raw = (
+        settings.OPS_CONTROL_TOWER_MANUAL_JSON
+        or os.getenv("OPS_CONTROL_TOWER_MANUAL_JSON")
+        or ""
+    ).strip()
+    data = _safe_json_loads(raw)
+    if not data:
+        return []
+    rows = data.get("ai_accounts") or data.get("accounts")
+    if not isinstance(rows, list):
+        return []
+    out: list[AIUsageAccount] = []
+    for r in rows:
+        if not isinstance(r, dict):
+            continue
+        try:
+            out.append(AIUsageAccount.model_validate(r))
+        except Exception as exc:
+            logger.debug("ops_control_tower.ai_account_skip", error=str(exc))
+    return out
+
+
+async def _openai_billing_probe(api_key: str) -> list[AIUsageAccount] | None:
+    """
+    Best-effort: OpenAI billing subscription endpoint (may 403 on restricted keys).
+    Returns None if not usable — callers should not treat as failure.
+    """
+    url = "https://api.openai.com/v1/dashboard/billing/subscription"
+    try:
+        async with httpx.AsyncClient(timeout=20.0) as client:
+            r = await client.get(
+                url,
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                },
+            )
+    except Exception as exc:
+        logger.debug("ops_control_tower.openai_billing_net", error=str(exc))
+        return None
+    if r.status_code != 200:
+        logger.debug(
+            "ops_control_tower.openai_billing_status",
+            status=r.status_code,
+        )
+        return None
+    try:
+        body = r.json()
+    except Exception:
+        return None
+    hard_limit = body.get("hard_limit_usd")
+    plan = body.get("plan") or {}
+    title = str(plan.get("title") or "openai_org")
+    return [
+        AIUsageAccount(
+            provider_name="openai",
+            account_name=title,
+            workspace_or_org=str(body.get("id") or "primary"),
+            model_name=None,
+            billing_cycle_start=None,
+            billing_cycle_end=None,
+            quota_type="billing_account",
+            quota_limit=float(hard_limit) if hard_limit is not None else None,
+            quota_used=None,
+            quota_remaining=None,
+            cost_to_date_usd=None,
+            estimated_runway_days=None,
+            refresh_source=SyncSourceType.DIRECT_API,
+            last_synced_at=_utcnow_iso(),
+            sync_confidence=0.85,
+            notes="Subscription object from OpenAI billing API (limits; not per-model spend).",
+        )
+    ]
+
+
+def _anthropic_placeholder() -> AIUsageAccount:
+    return AIUsageAccount(
+        provider_name="anthropic",
+        account_name="primary",
+        workspace_or_org=None,
+        model_name=None,
+        billing_cycle_start=None,
+        billing_cycle_end=None,
+        quota_type="usage_api_not_wired",
+        quota_limit=None,
+        quota_used=None,
+        quota_remaining=None,
+        cost_to_date_usd=None,
+        estimated_runway_days=None,
+        refresh_source=SyncSourceType.DASHBOARD_PLACEHOLDER,
+        last_synced_at=_utcnow_iso(),
+        sync_confidence=0.0,
+        notes=(
+            "Anthropic usage is not pulled automatically in this build. "
+            "Export from console.anthropic.com or add OPS_CONTROL_TOWER_MANUAL_JSON."
+        ),
+    )
+
+
+def _cursor_copilot_placeholders() -> list[AIUsageAccount]:
+    return [
+        AIUsageAccount(
+            provider_name="cursor",
+            account_name="team_pool",
+            quota_type="manual_or_import",
+            refresh_source=SyncSourceType.MANUAL_OVERRIDE,
+            last_synced_at=_utcnow_iso(),
+            sync_confidence=0.0,
+            notes="Cursor billing has no public usage API here — paste usage into manual JSON.",
+        ),
+        AIUsageAccount(
+            provider_name="github_copilot",
+            account_name="org_seat",
+            quota_type="aggregated",
+            refresh_source=SyncSourceType.DASHBOARD_PLACEHOLDER,
+            last_synced_at=_utcnow_iso(),
+            sync_confidence=0.0,
+            notes="Copilot: use GitHub billing export or manual JSON until an API is configured.",
+        ),
+    ]
+
+
+def _aggregate_ai_metrics(accounts: list[AIUsageAccount]) -> dict[str, Any]:
+    by_provider: dict[str, float] = {}
+    by_model: dict[str, float] = {}
+    for a in accounts:
+        c = a.cost_to_date_usd or 0.0
+        if c and c > 0:
+            by_provider[a.provider_name] = by_provider.get(a.provider_name, 0.0) + c
+            if a.model_name:
+                by_model[a.model_name] = by_model.get(a.model_name, 0.0) + c
+    burn = sorted(
+        [{"model": k, "cost_usd": v} for k, v in by_model.items()],
+        key=lambda x: -x["cost_usd"],
+    )[:12]
+    return {
+        "total_cost_usd_by_provider": by_provider,
+        "total_cost_usd_by_model": by_model,
+        "top_models_by_spend": burn,
+    }
+
+
+def _build_alerts(accounts: list[AIUsageAccount]) -> list[dict[str, Any]]:
+    alerts: list[dict[str, Any]] = []
+    for a in accounts:
+        if a.quota_limit and a.quota_used is not None and a.quota_limit > 0:
+            pct = (a.quota_used / a.quota_limit) * 100.0
+            if pct >= 85:
+                alerts.append(
+                    {
+                        "severity": "warning",
+                        "type": "quota_nearing_exhaustion",
+                        "message": f"{a.provider_name}/{a.account_name} at {pct:.0f}% of quota",
+                        "provider": a.provider_name,
+                    }
+                )
+    return alerts
+
+
+# ── GitHub ────────────────────────────────────────────────────────────────────
+
+
+async def _github_repo_intel(token: str, repo: str) -> dict[str, Any] | None:
+    owner, _, name = repo.partition("/")
+    if not name:
+        return None
+    base = "https://api.github.com"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    try:
+        async with httpx.AsyncClient(timeout=25.0) as client:
+            r = await client.get(f"{base}/repos/{owner}/{name}", headers=headers)
+            if r.status_code != 200:
+                return {
+                    "ok": False,
+                    "status": r.status_code,
+                    "source_type": SyncSourceType.DIRECT_API,
+                    "sync_confidence": 0.0,
+                    "error": r.text[:200],
+                }
+            repo_json = r.json()
+            lang_r = await client.get(
+                f"{base}/repos/{owner}/{name}/languages", headers=headers
+            )
+            langs: dict[str, int] = {}
+            if lang_r.status_code == 200:
+                langs = {str(k): int(v) for k, v in (lang_r.json() or {}).items()}
+            part_r = await client.get(
+                f"{base}/repos/{owner}/{name}/stats/participation", headers=headers
+            )
+            weeks: list[int] = []
+            if part_r.status_code == 200:
+                pj = part_r.json() or {}
+                weeks = list(pj.get("all") or [])[-12:]
+            open_prs = None
+            pr_r = await client.get(
+                f"{base}/repos/{owner}/{name}/pulls?state=open&per_page=1",
+                headers=headers,
+            )
+            if pr_r.status_code == 200:
+                link = pr_r.headers.get("link") or ""
+                if 'rel="last"' in link:
+                    import re
+
+                    m = re.search(r"page=(\d+)>; rel=\"last\"", link)
+                    if m:
+                        open_prs = int(m.group(1))
+                elif isinstance(pr_r.json(), list):
+                    open_prs = len(pr_r.json())
+            total_bytes = sum(langs.values()) if langs else None
+            return {
+                "ok": True,
+                "source_type": SyncSourceType.DIRECT_API,
+                "sync_confidence": 0.9,
+                "last_synced_at": _utcnow_iso(),
+                "repository": repo,
+                "description": repo_json.get("description"),
+                "default_branch": repo_json.get("default_branch"),
+                "stars": repo_json.get("stargazers_count"),
+                "forks": repo_json.get("forks_count"),
+                "open_issues": repo_json.get("open_issues_count"),
+                "open_pull_requests_hint": open_prs,
+                "size_kb": repo_json.get("size"),
+                "pushed_at": repo_json.get("pushed_at"),
+                "languages_bytes": langs,
+                "languages_total_bytes": total_bytes,
+                "commit_activity_last_12_weeks": weeks,
+                "notes": (
+                    "LOC by language from /languages (bytes, not lines). "
+                    "Open PR count from Link header when paginated; may be null."
+                ),
+            }
+    except Exception as exc:
+        logger.warning("ops_control_tower.github_error", error=str(exc))
+        return {
+            "ok": False,
+            "source_type": SyncSourceType.DIRECT_API,
+            "sync_confidence": 0.0,
+            "error": str(exc),
+        }
+
+
+# ── Deployments (best-effort) ─────────────────────────────────────────────────
+
+
+async def _vercel_deployments_hint() -> dict[str, Any]:
+    tok = settings.OPS_VERCEL_TOKEN
+    pid = settings.OPS_VERCEL_PROJECT_ID
+    team = settings.OPS_VERCEL_TEAM_ID
+    if not tok or not pid:
+        return {
+            "configured": False,
+            "source_type": SyncSourceType.MANUAL_OVERRIDE,
+            "notes": "Set OPS_VERCEL_TOKEN and OPS_VERCEL_PROJECT_ID (and OPS_VERCEL_TEAM_ID if on team scope).",
+        }
+    q = f"projectId={pid}&limit=5"
+    if team:
+        q += f"&teamId={team}"
+    try:
+        async with httpx.AsyncClient(timeout=20.0) as client:
+            r = await client.get(
+                f"https://api.vercel.com/v6/deployments?{q}",
+                headers={"Authorization": f"Bearer {tok}"},
+            )
+        if r.status_code != 200:
+            return {
+                "configured": True,
+                "ok": False,
+                "status": r.status_code,
+                "source_type": SyncSourceType.DIRECT_API,
+                "body": r.text[:300],
+            }
+        data = r.json()
+        dep = data.get("deployments") or []
+        items = []
+        for d in dep[:8]:
+            items.append(
+                {
+                    "id": d.get("uid"),
+                    "url": d.get("url"),
+                    "state": d.get("state"),
+                    "created": d.get("createdAt"),
+                    "target": d.get("target"),
+                }
+            )
+        return {
+            "configured": True,
+            "ok": True,
+            "source_type": SyncSourceType.DIRECT_API,
+            "sync_confidence": 0.8,
+            "last_synced_at": _utcnow_iso(),
+            "deployments": items,
+        }
+    except Exception as exc:
+        return {
+            "configured": True,
+            "ok": False,
+            "error": str(exc),
+            "source_type": SyncSourceType.DIRECT_API,
+        }
+
+
+def _railway_placeholder() -> dict[str, Any]:
+    if not settings.OPS_RAILWAY_TOKEN:
+        return {
+            "configured": False,
+            "source_type": SyncSourceType.MANUAL_OVERRIDE,
+            "notes": "Railway GraphQL not wired. Set OPS_RAILWAY_TOKEN for future automation.",
+        }
+    return {
+        "configured": True,
+        "source_type": SyncSourceType.DASHBOARD_PLACEHOLDER,
+        "sync_confidence": 0.0,
+        "notes": "Token present; per-service deploy feed not implemented in this slice — use Railway UI or extend adapter.",
+    }
+
+
+# ── Errors / system (reuse in-process metrics) ────────────────────────────────
+
+
+def _error_unified_panel() -> dict[str, Any]:
+    http_stats = http_stats_last_hours(24.0)
+    return {
+        "api_process_24h": {
+            "http_5xx_rate_pct": http_stats.get("error_rate_pct"),
+            "http_sample_count": http_stats.get("sample_count"),
+            "p50_ms": http_stats.get("p50_ms"),
+            "p95_ms": http_stats.get("p95_ms"),
+            "source": "in_process_ring_buffer",
+        },
+        "external_connectors": [
+            {
+                "name": "sentry",
+                "status": "not_queried",
+                "source_type": SyncSourceType.MANUAL_OVERRIDE,
+                "notes": "Wire Sentry API or embed issue counts in OPS_CONTROL_TOWER_MANUAL_JSON.",
+            },
+            {
+                "name": "posthog",
+                "status": "not_queried",
+                "source_type": SyncSourceType.MANUAL_OVERRIDE,
+                "notes": "Use PostHog project API for error trends.",
+            },
+            {
+                "name": "stripe_webhooks",
+                "status": "not_queried",
+                "source_type": SyncSourceType.MANUAL_OVERRIDE,
+                "notes": "Surface Stripe Dashboard webhook delivery failures.",
+            },
+        ],
+        "top_recurring_messages": [],
+    }
+
+
+def _integrations_matrix() -> list[dict[str, Any]]:
+    return [
+        {
+            "id": "openai",
+            "automation": "partial" if settings.OPENAI_KEY else "none",
+            "detail": "Billing subscription probe when OPENAI_KEY is set.",
+        },
+        {
+            "id": "anthropic",
+            "automation": "none",
+            "detail": "No usage pull in this build.",
+        },
+        {
+            "id": "github",
+            "automation": "full" if settings.OPS_GITHUB_TOKEN else "none",
+            "detail": "REST repo + languages + participation when token set.",
+        },
+        {
+            "id": "vercel",
+            "automation": "partial" if settings.OPS_VERCEL_TOKEN else "none",
+        },
+        {
+            "id": "railway",
+            "automation": "none",
+        },
+    ]
+
+
+def _audit_stub() -> list[dict[str, Any]]:
+    return [
+        {
+            "at": _utcnow_iso(),
+            "event": "control_tower_snapshot",
+            "message": "In-memory TTL cache; no persistent audit log yet.",
+        }
+    ]
+
+
+async def build_control_tower_snapshot() -> dict[str, Any]:
+    accounts: list[AIUsageAccount] = []
+    accounts.extend(_manual_accounts_from_env())
+
+    okey = settings.OPENAI_KEY
+    if okey:
+        oa = await _openai_billing_probe(okey)
+        if oa:
+            accounts.extend(oa)
+    if not any(a.provider_name == "anthropic" for a in accounts):
+        accounts.append(_anthropic_placeholder())
+    accounts.extend(_cursor_copilot_placeholders())
+
+    ai_metrics = _aggregate_ai_metrics(accounts)
+    alerts = _build_alerts(accounts)
+
+    gh: dict[str, Any] | None = None
+    if settings.OPS_GITHUB_TOKEN and settings.OPS_GITHUB_REPO:
+        gh = await _github_repo_intel(
+            settings.OPS_GITHUB_TOKEN, settings.OPS_GITHUB_REPO.strip()
+        )
+
+    vercel = await _vercel_deployments_hint()
+    railway = _railway_placeholder()
+    errors = _error_unified_panel()
+
+    manual_merge = _safe_json_loads(
+        (
+            settings.OPS_CONTROL_TOWER_MANUAL_JSON
+            or os.getenv("OPS_CONTROL_TOWER_MANUAL_JSON")
+            or ""
+        ).strip()
+    )
+    snapshot: dict[str, Any] = {
+        "generated_at": _utcnow_iso(),
+        "cache_ttl_seconds": int(_CACHE_TTL),
+        "ai_usage": {
+            "accounts": [a.model_dump() for a in accounts],
+            **ai_metrics,
+        },
+        "github": gh,
+        "deployments": {"vercel": vercel, "railway": railway},
+        "errors": errors,
+        "integrations": _integrations_matrix(),
+        "alerts": alerts,
+        "audit_sync_logs": _audit_stub(),
+        "automation_summary": {
+            "fully_automated": [
+                x["id"] for x in _integrations_matrix() if x.get("automation") == "full"
+            ],
+            "partial": [
+                x["id"]
+                for x in _integrations_matrix()
+                if x.get("automation") == "partial"
+            ],
+            "manual_or_placeholder": [
+                x["id"]
+                for x in _integrations_matrix()
+                if x.get("automation") in ("none", None)
+            ],
+        },
+        "limitations": (
+            "Per-model spend and multi-account Claude/Cursor/Copilot require manual JSON or future billing APIs. "
+            "Vercel/Railway surfaces are feature-flagged via env. Error panel uses in-process HTTP stats only unless extended."
+        ),
+    }
+    if manual_merge:
+        snapshot["manual_overrides_merged"] = True
+        for k, v in manual_merge.items():
+            if k in snapshot and isinstance(snapshot[k], dict) and isinstance(v, dict):
+                snapshot[k] = {**snapshot[k], **v}
+            else:
+                snapshot[k] = v
+    return snapshot
+
+
+async def get_control_tower_snapshot_cached() -> dict[str, Any]:
+    global _CACHE, _CACHE_AT
+    now = time.monotonic()
+    if _CACHE is not None and (now - _CACHE_AT) < _CACHE_TTL:
+        return {**_CACHE, "cache_hit": True}
+    snap = await build_control_tower_snapshot()
+    _CACHE = snap
+    _CACHE_AT = now
+    return {**snap, "cache_hit": False}

--- a/neufin-web/app/admin/AdminShell.tsx
+++ b/neufin-web/app/admin/AdminShell.tsx
@@ -11,6 +11,7 @@ import { Menu, X } from "lucide-react";
 
 const LINKS = [
   { href: "/admin", label: "Overview" },
+  { href: "/admin/ops", label: "Control tower" },
   { href: "/admin/users", label: "Users" },
   { href: "/admin/partners", label: "Partners" },
   { href: "/admin/api-keys", label: "API Keys" },

--- a/neufin-web/app/admin/ops/page.tsx
+++ b/neufin-web/app/admin/ops/page.tsx
@@ -1,0 +1,9 @@
+import OpsControlTowerPanel from "@/components/admin/OpsControlTowerPanel";
+
+export default function AdminOpsPage() {
+  return (
+    <div className="p-6 max-w-6xl">
+      <OpsControlTowerPanel />
+    </div>
+  );
+}

--- a/neufin-web/app/admin/page.tsx
+++ b/neufin-web/app/admin/page.tsx
@@ -66,6 +66,11 @@ function MetricCard({
 }
 
 const QUICK_LINKS = [
+  {
+    href: "/admin/ops",
+    label: "Control tower",
+    hint: "AI usage, repo, deploys, errors",
+  },
   { href: "/admin/users", label: "Users", hint: "Subscriptions and access" },
   { href: "/admin/partners", label: "Partners", hint: "API customers and keys" },
   { href: "/admin/api-keys", label: "API Keys", hint: "Issue, revoke, rate limit" },

--- a/neufin-web/app/api/admin/control-tower/route.ts
+++ b/neufin-web/app/api/admin/control-tower/route.ts
@@ -1,0 +1,8 @@
+import { NextRequest } from "next/server";
+import { proxyBackendJson } from "@/lib/admin-backend-proxy";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  return proxyBackendJson(req, "/api/admin/control-tower", { method: "GET" });
+}

--- a/neufin-web/components/admin/OpsControlTowerPanel.tsx
+++ b/neufin-web/components/admin/OpsControlTowerPanel.tsx
@@ -1,0 +1,689 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { apiFetch } from "@/lib/api-client";
+import clsx from "clsx";
+
+type AIAccount = {
+  provider_name: string;
+  account_name: string;
+  workspace_or_org?: string | null;
+  model_name?: string | null;
+  billing_cycle_start?: string | null;
+  billing_cycle_end?: string | null;
+  quota_type?: string;
+  quota_limit?: number | null;
+  quota_used?: number | null;
+  quota_remaining?: number | null;
+  cost_to_date_usd?: number | null;
+  estimated_runway_days?: number | null;
+  refresh_source: string;
+  last_synced_at?: string | null;
+  sync_confidence?: number;
+  notes?: string | null;
+};
+
+type ControlTower = {
+  generated_at?: string;
+  cache_hit?: boolean;
+  cache_ttl_seconds?: number;
+  limitations?: string;
+  manual_overrides_merged?: boolean;
+  ai_usage?: {
+    accounts: AIAccount[];
+    total_cost_usd_by_provider?: Record<string, number>;
+    total_cost_usd_by_model?: Record<string, number>;
+    top_models_by_spend?: { model: string; cost_usd: number }[];
+  };
+  github?: Record<string, unknown> | null;
+  deployments?: {
+    vercel?: Record<string, unknown>;
+    railway?: Record<string, unknown>;
+  };
+  errors?: Record<string, unknown>;
+  integrations?: { id: string; automation?: string; detail?: string }[];
+  alerts?: {
+    severity?: string;
+    type?: string;
+    message?: string;
+    provider?: string;
+  }[];
+  audit_sync_logs?: { at?: string; event?: string; message?: string }[];
+  automation_summary?: {
+    fully_automated?: string[];
+    partial?: string[];
+    manual_or_placeholder?: string[];
+  };
+};
+
+const SECTIONS = [
+  { id: "overview", label: "Overview" },
+  { id: "ai-usage", label: "AI usage" },
+  { id: "repo", label: "Repo" },
+  { id: "deployments", label: "Deployments" },
+  { id: "errors", label: "Errors" },
+  { id: "integrations", label: "Integrations" },
+  { id: "audit", label: "Audit / sync" },
+] as const;
+
+function fmtUsd(n: number | null | undefined) {
+  if (n == null || Number.isNaN(n)) return "—";
+  return `$${n.toLocaleString(undefined, { maximumFractionDigits: 2 })}`;
+}
+
+function fmtPct(n: number | null | undefined) {
+  if (n == null || Number.isNaN(n)) return "—";
+  return `${(n * 100).toFixed(0)}%`;
+}
+
+function SyncBadge({ confidence }: { confidence?: number }) {
+  const c = confidence ?? 0;
+  const label =
+    c >= 0.85 ? "high" : c >= 0.5 ? "medium" : c > 0 ? "low" : "manual";
+  return (
+    <span
+      className={clsx(
+        "rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide",
+        label === "high" && "bg-emerald-950/80 text-emerald-300",
+        label === "medium" && "bg-amber-950/80 text-amber-200",
+        (label === "low" || label === "manual") &&
+          "bg-zinc-800 text-zinc-400",
+      )}
+    >
+      sync {label} · {c.toFixed(2)}
+    </span>
+  );
+}
+
+function SourcePill({ source }: { source: string }) {
+  return (
+    <span className="rounded-md border border-zinc-700/80 bg-zinc-900/60 px-2 py-0.5 font-mono text-[11px] text-zinc-400">
+      {source.replace(/_/g, " ")}
+    </span>
+  );
+}
+
+function WeekHeatmap({ weeks }: { weeks: number[] }) {
+  if (!weeks.length) return <p className="text-sm text-zinc-500">No data</p>;
+  const max = Math.max(...weeks, 1);
+  return (
+    <div className="flex h-10 items-end gap-px">
+      {weeks.map((w, i) => (
+        <div
+          key={i}
+          title={`Week ${i + 1}: ${w} commits`}
+          className="min-w-[6px] flex-1 rounded-sm bg-cyan-900/40"
+          style={{
+            height: `${Math.max(8, (w / max) * 100)}%`,
+            opacity: 0.35 + (w / max) * 0.65,
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+export default function OpsControlTowerPanel() {
+  const [data, setData] = useState<ControlTower | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [active, setActive] = useState<(typeof SECTIONS)[number]["id"]>(
+    "overview",
+  );
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setErr(null);
+    try {
+      const res = await apiFetch("/api/admin/control-tower", {
+        cache: "no-store",
+      });
+      if (!res.ok) throw new Error(`${res.status}`);
+      const j = (await res.json()) as ControlTower;
+      setData(j);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "Failed to load");
+      setData(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const accounts = data?.ai_usage?.accounts ?? [];
+  const byProv = data?.ai_usage?.total_cost_usd_by_provider ?? {};
+  const topModels = data?.ai_usage?.top_models_by_spend ?? [];
+  const anthropicAccounts = accounts.filter(
+    (a) => a.provider_name === "anthropic",
+  );
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-col gap-4 border-b border-zinc-800/80 pb-6 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <p className="text-xs font-medium uppercase tracking-widest text-cyan-500/90">
+            Operations
+          </p>
+          <h1 className="mt-1 text-2xl font-semibold text-white">
+            Control tower
+          </h1>
+          <p className="mt-2 max-w-2xl text-sm leading-relaxed text-zinc-500">
+            Unified visibility for LLM spend, repository signals, deploys, and
+            process errors. Source types and sync confidence are explicit — we do
+            not imply automation where APIs are not wired.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3 text-xs text-zinc-500">
+          <span>
+            Generated:{" "}
+            <span className="font-mono text-zinc-300">
+              {data?.generated_at ?? "—"}
+            </span>
+          </span>
+          <span
+            className={clsx(
+              "rounded-full px-2 py-0.5",
+              data?.cache_hit
+                ? "bg-zinc-800 text-zinc-400"
+                : "bg-emerald-950/50 text-emerald-300",
+            )}
+          >
+            {data?.cache_hit ? "cache hit" : "fresh fetch"}
+          </span>
+          <button
+            type="button"
+            onClick={() => void load()}
+            disabled={loading}
+            className="rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-1.5 text-sm text-zinc-200 hover:border-zinc-600 hover:bg-zinc-800 disabled:opacity-50"
+          >
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-1 border-b border-zinc-800/60 pb-3">
+        {SECTIONS.map((s) => (
+          <button
+            key={s.id}
+            type="button"
+            onClick={() => {
+              setActive(s.id);
+              document.getElementById(s.id)?.scrollIntoView({
+                behavior: "smooth",
+                block: "start",
+              });
+            }}
+            className={clsx(
+              "rounded-lg px-3 py-1.5 text-sm transition-colors",
+              active === s.id
+                ? "bg-zinc-800 text-white"
+                : "text-zinc-500 hover:bg-zinc-900 hover:text-zinc-300",
+            )}
+          >
+            {s.label}
+          </button>
+        ))}
+      </div>
+
+      {err && (
+        <div className="rounded-xl border border-red-900/50 bg-red-950/30 px-4 py-3 text-sm text-red-200">
+          {err}
+        </div>
+      )}
+
+      {loading && !data && (
+        <p className="text-sm text-zinc-500">Loading snapshot…</p>
+      )}
+
+      {data && (
+        <>
+          <section id="overview" className="scroll-mt-24 space-y-4">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-zinc-400">
+              Overview
+            </h2>
+            {data.manual_overrides_merged && (
+              <p className="rounded-lg border border-amber-900/40 bg-amber-950/20 px-3 py-2 text-sm text-amber-100/90">
+                Manual JSON overrides merged into this snapshot (
+                <code className="text-amber-200/90">OPS_CONTROL_TOWER_MANUAL_JSON</code>
+                ).
+              </p>
+            )}
+            <div className="grid gap-3 sm:grid-cols-3">
+              <div className="rounded-xl border border-zinc-800 bg-zinc-900/40 p-4">
+                <p className="text-xs uppercase text-zinc-500">Automated</p>
+                <p className="mt-1 text-lg text-white">
+                  {(data.automation_summary?.fully_automated ?? []).join(", ") ||
+                    "—"}
+                </p>
+              </div>
+              <div className="rounded-xl border border-zinc-800 bg-zinc-900/40 p-4">
+                <p className="text-xs uppercase text-zinc-500">Partial</p>
+                <p className="mt-1 text-lg text-white">
+                  {(data.automation_summary?.partial ?? []).join(", ") || "—"}
+                </p>
+              </div>
+              <div className="rounded-xl border border-zinc-800 bg-zinc-900/40 p-4">
+                <p className="text-xs uppercase text-zinc-500">
+                  Manual / placeholder
+                </p>
+                <p className="mt-1 text-lg text-white">
+                  {(data.automation_summary?.manual_or_placeholder ?? []).join(
+                    ", ",
+                  ) || "—"}
+                </p>
+              </div>
+            </div>
+            <p className="text-sm leading-relaxed text-zinc-500">
+              {data.limitations}
+            </p>
+            <div>
+              <h3 className="mb-2 text-xs font-semibold uppercase text-zinc-500">
+                Alerts
+              </h3>
+              {(data.alerts ?? []).length === 0 ? (
+                <p className="text-sm text-zinc-500">No active alerts.</p>
+              ) : (
+                <ul className="space-y-2">
+                  {(data.alerts ?? []).map((a, i) => (
+                    <li
+                      key={i}
+                      className="flex items-start gap-2 rounded-lg border border-zinc-800 bg-zinc-900/30 px-3 py-2 text-sm"
+                    >
+                      <span
+                        className={clsx(
+                          "mt-0.5 h-2 w-2 shrink-0 rounded-full",
+                          a.severity === "warning"
+                            ? "bg-amber-400"
+                            : "bg-zinc-500",
+                        )}
+                      />
+                      <span className="text-zinc-300">{a.message}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </section>
+
+          <section id="ai-usage" className="scroll-mt-24 space-y-4">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-zinc-400">
+              AI usage observatory
+            </h2>
+            <div className="grid gap-3 md:grid-cols-3">
+              <div className="rounded-xl border border-zinc-800 bg-zinc-900/30 p-4">
+                <p className="text-xs uppercase text-zinc-500">
+                  Spend by provider
+                </p>
+                <ul className="mt-2 space-y-1 text-sm">
+                  {Object.keys(byProv).length === 0 ? (
+                    <li className="text-zinc-500">
+                      No cost rows (add manual JSON or wire billing APIs).
+                    </li>
+                  ) : (
+                    Object.entries(byProv).map(([k, v]) => (
+                      <li
+                        key={k}
+                        className="flex justify-between gap-2 font-mono text-zinc-300"
+                      >
+                        <span>{k}</span>
+                        <span>{fmtUsd(v)}</span>
+                      </li>
+                    ))
+                  )}
+                </ul>
+              </div>
+              <div className="rounded-xl border border-zinc-800 bg-zinc-900/30 p-4">
+                <p className="text-xs uppercase text-zinc-500">
+                  Top burn-rate models
+                </p>
+                <ul className="mt-2 space-y-1 text-sm">
+                  {topModels.length === 0 ? (
+                    <li className="text-zinc-500">No per-model costs yet.</li>
+                  ) : (
+                    topModels.map((m) => (
+                      <li
+                        key={m.model}
+                        className="flex justify-between gap-2 font-mono text-zinc-300"
+                      >
+                        <span className="truncate">{m.model}</span>
+                        <span>{fmtUsd(m.cost_usd)}</span>
+                      </li>
+                    ))
+                  )}
+                </ul>
+              </div>
+              <div className="rounded-xl border border-zinc-800 bg-zinc-900/30 p-4">
+                <p className="text-xs uppercase text-zinc-500">
+                  Claude accounts
+                </p>
+                {anthropicAccounts.length === 0 ? (
+                  <p className="mt-2 text-sm text-zinc-500">
+                    No anthropic rows — placeholder or add manual accounts.
+                  </p>
+                ) : (
+                  <ul className="mt-2 space-y-2">
+                    {anthropicAccounts.map((a, i) => (
+                      <li
+                        key={i}
+                        className="rounded border border-zinc-800/80 bg-black/20 px-2 py-1.5 text-sm"
+                      >
+                        <div className="flex justify-between gap-2">
+                          <span className="text-zinc-200">{a.account_name}</span>
+                          <SyncBadge confidence={a.sync_confidence} />
+                        </div>
+                        {a.notes && (
+                          <p className="mt-1 text-xs text-zinc-500">{a.notes}</p>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </div>
+            <div className="overflow-x-auto rounded-xl border border-zinc-800">
+              <table className="min-w-full text-left text-sm">
+                <thead>
+                  <tr className="border-b border-zinc-800 bg-zinc-900/50 text-xs uppercase text-zinc-500">
+                    <th className="px-3 py-2 font-medium">Provider</th>
+                    <th className="px-3 py-2 font-medium">Account</th>
+                    <th className="px-3 py-2 font-medium">Model</th>
+                    <th className="px-3 py-2 font-medium">Quota</th>
+                    <th className="px-3 py-2 font-medium">Cost</th>
+                    <th className="px-3 py-2 font-medium">Source</th>
+                    <th className="px-3 py-2 font-medium">Sync</th>
+                    <th className="px-3 py-2 font-medium">Updated</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {accounts.map((a, i) => (
+                    <tr
+                      key={i}
+                      className="border-b border-zinc-800/60 hover:bg-zinc-900/30"
+                    >
+                      <td className="px-3 py-2 font-medium text-zinc-200">
+                        {a.provider_name}
+                      </td>
+                      <td className="px-3 py-2 text-zinc-300">
+                        {a.account_name}
+                        {a.workspace_or_org ? (
+                          <span className="ml-1 text-xs text-zinc-500">
+                            ({a.workspace_or_org})
+                          </span>
+                        ) : null}
+                      </td>
+                      <td className="px-3 py-2 font-mono text-xs text-zinc-400">
+                        {a.model_name ?? "—"}
+                      </td>
+                      <td className="px-3 py-2 text-zinc-400">
+                        {a.quota_limit != null && a.quota_used != null ? (
+                          <>
+                            {a.quota_used.toLocaleString()} /{" "}
+                            {a.quota_limit.toLocaleString()}{" "}
+                            <span className="text-zinc-600">
+                              (
+                              {fmtPct(
+                                a.quota_limit > 0
+                                  ? a.quota_used / a.quota_limit
+                                  : undefined,
+                              )}
+                              )
+                            </span>
+                          </>
+                        ) : (
+                          <span className="text-zinc-600">—</span>
+                        )}
+                      </td>
+                      <td className="px-3 py-2 tabular-nums text-zinc-300">
+                        {fmtUsd(a.cost_to_date_usd)}
+                      </td>
+                      <td className="px-3 py-2">
+                        <SourcePill source={a.refresh_source} />
+                      </td>
+                      <td className="px-3 py-2">
+                        <SyncBadge confidence={a.sync_confidence} />
+                      </td>
+                      <td className="px-3 py-2 font-mono text-xs text-zinc-500">
+                        {a.last_synced_at ?? "—"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            {(accounts.some((a) => a.notes) ||
+              accounts.some((a) => a.sync_confidence === 0)) && (
+              <div className="space-y-2">
+                <h3 className="text-xs font-semibold uppercase text-zinc-500">
+                  Notes & limitations
+                </h3>
+                <ul className="list-disc space-y-1 pl-5 text-sm text-zinc-500">
+                  {accounts.map(
+                    (a, i) =>
+                      a.notes && (
+                        <li key={i}>
+                          <span className="text-zinc-400">
+                            {a.provider_name}/{a.account_name}:
+                          </span>{" "}
+                          {a.notes}
+                        </li>
+                      ),
+                  )}
+                </ul>
+              </div>
+            )}
+          </section>
+
+          <section id="repo" className="scroll-mt-24 space-y-4">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-zinc-400">
+              GitHub / codebase
+            </h2>
+            {!data.github ? (
+              <p className="rounded-xl border border-zinc-800 bg-zinc-900/30 px-4 py-3 text-sm text-zinc-500">
+                No GitHub snapshot — set{" "}
+                <code className="text-zinc-400">OPS_GITHUB_TOKEN</code> and{" "}
+                <code className="text-zinc-400">OPS_GITHUB_REPO</code> on the API.
+              </p>
+            ) : data.github.ok === false ? (
+              <p className="rounded-xl border border-red-900/40 bg-red-950/20 px-4 py-3 text-sm text-red-200">
+                GitHub error:{" "}
+                {String(
+                  (data.github as { error?: string }).error ??
+                    (data.github as { status?: number }).status ??
+                    "unknown",
+                )}
+              </p>
+            ) : (
+              <div className="grid gap-4 lg:grid-cols-2">
+                <div className="rounded-xl border border-zinc-800 bg-zinc-900/40 p-4 space-y-3">
+                  <div className="flex flex-wrap items-baseline justify-between gap-2">
+                    <p className="text-lg font-medium text-white">
+                      {(data.github as { repository?: string }).repository}
+                    </p>
+                    <span className="text-xs text-zinc-500">
+                      last sync{" "}
+                      {(data.github as { last_synced_at?: string })
+                        .last_synced_at ?? "—"}
+                    </span>
+                  </div>
+                  <p className="text-sm text-zinc-500">
+                    {(data.github as { description?: string }).description ??
+                      "—"}
+                  </p>
+                  <div className="grid grid-cols-2 gap-2 text-sm">
+                    <div>
+                      <p className="text-xs text-zinc-500">Default branch</p>
+                      <p className="font-mono text-zinc-300">
+                        {(data.github as { default_branch?: string })
+                          .default_branch ?? "—"}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-xs text-zinc-500">Open PRs (hint)</p>
+                      <p className="text-zinc-300">
+                        {String(
+                          (data.github as { open_pull_requests_hint?: number })
+                            .open_pull_requests_hint ?? "—",
+                        )}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-xs text-zinc-500">Stars</p>
+                      <p className="text-zinc-300">
+                        {String(
+                          (data.github as { stars?: number }).stars ?? "—",
+                        )}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-xs text-zinc-500">Repo size (KB)</p>
+                      <p className="text-zinc-300">
+                        {String((data.github as { size_kb?: number }).size_kb ?? "—")}
+                      </p>
+                    </div>
+                  </div>
+                  <p className="text-xs text-zinc-600">
+                    {(data.github as { notes?: string }).notes}
+                  </p>
+                </div>
+                <div className="rounded-xl border border-zinc-800 bg-zinc-900/40 p-4 space-y-3">
+                  <p className="text-xs font-semibold uppercase text-zinc-500">
+                    Languages (bytes from GitHub API)
+                  </p>
+                  <ul className="max-h-48 space-y-1 overflow-auto text-sm">
+                    {Object.entries(
+                      ((data.github as { languages_bytes?: Record<string, number> })
+                        .languages_bytes ?? {}) as Record<string, number>,
+                    )
+                      .sort((a, b) => b[1] - a[1])
+                      .slice(0, 14)
+                      .map(([lang, bytes]) => (
+                        <li
+                          key={lang}
+                          className="flex justify-between gap-2 font-mono text-xs text-zinc-400"
+                        >
+                          <span>{lang}</span>
+                          <span>{bytes.toLocaleString()} B</span>
+                        </li>
+                      ))}
+                  </ul>
+                  <div>
+                    <p className="mb-1 text-xs font-semibold uppercase text-zinc-500">
+                      Commit activity (12 weeks)
+                    </p>
+                    <WeekHeatmap
+                      weeks={
+                        (data.github as { commit_activity_last_12_weeks?: number[] })
+                          .commit_activity_last_12_weeks ?? []
+                      }
+                    />
+                  </div>
+                </div>
+              </div>
+            )}
+          </section>
+
+          <section id="deployments" className="scroll-mt-24 space-y-4">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-zinc-400">
+              Deployments
+            </h2>
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="rounded-xl border border-zinc-800 bg-zinc-900/40 p-4">
+                <p className="text-xs font-semibold uppercase text-cyan-600/90">
+                  Vercel
+                </p>
+                <pre className="mt-2 max-h-64 overflow-auto text-xs text-zinc-400">
+                  {JSON.stringify(data.deployments?.vercel ?? {}, null, 2)}
+                </pre>
+              </div>
+              <div className="rounded-xl border border-zinc-800 bg-zinc-900/40 p-4">
+                <p className="text-xs font-semibold uppercase text-zinc-500">
+                  Railway
+                </p>
+                <pre className="mt-2 max-h-64 overflow-auto text-xs text-zinc-400">
+                  {JSON.stringify(data.deployments?.railway ?? {}, null, 2)}
+                </pre>
+              </div>
+            </div>
+          </section>
+
+          <section id="errors" className="scroll-mt-24 space-y-4">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-zinc-400">
+              Errors & API health
+            </h2>
+            <pre className="max-h-96 overflow-auto rounded-xl border border-zinc-800 bg-black/30 p-4 text-xs text-zinc-400">
+              {JSON.stringify(data.errors ?? {}, null, 2)}
+            </pre>
+          </section>
+
+          <section id="integrations" className="scroll-mt-24 space-y-4">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-zinc-400">
+              Integrations
+            </h2>
+            <div className="overflow-x-auto rounded-xl border border-zinc-800">
+              <table className="min-w-full text-left text-sm">
+                <thead>
+                  <tr className="border-b border-zinc-800 bg-zinc-900/50 text-xs uppercase text-zinc-500">
+                    <th className="px-3 py-2">ID</th>
+                    <th className="px-3 py-2">Automation</th>
+                    <th className="px-3 py-2">Detail</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(data.integrations ?? []).map((row) => (
+                    <tr
+                      key={row.id}
+                      className="border-b border-zinc-800/60 hover:bg-zinc-900/30"
+                    >
+                      <td className="px-3 py-2 font-mono text-zinc-300">
+                        {row.id}
+                      </td>
+                      <td className="px-3 py-2">
+                        <span
+                          className={clsx(
+                            "rounded px-2 py-0.5 text-xs font-medium",
+                            row.automation === "full" &&
+                              "bg-emerald-950/60 text-emerald-300",
+                            row.automation === "partial" &&
+                              "bg-amber-950/60 text-amber-200",
+                            (row.automation === "none" || !row.automation) &&
+                              "bg-zinc-800 text-zinc-500",
+                          )}
+                        >
+                          {row.automation ?? "—"}
+                        </span>
+                      </td>
+                      <td className="px-3 py-2 text-zinc-500">
+                        {row.detail ?? "—"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section id="audit" className="scroll-mt-24 space-y-4">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-zinc-400">
+              Audit / sync logs
+            </h2>
+            <ul className="space-y-2">
+              {(data.audit_sync_logs ?? []).map((log, i) => (
+                <li
+                  key={i}
+                  className="rounded-lg border border-zinc-800 bg-zinc-900/30 px-3 py-2 font-mono text-xs text-zinc-400"
+                >
+                  <span className="text-zinc-500">{log.at}</span>{" "}
+                  <span className="text-zinc-300">{log.event}</span> —{" "}
+                  {log.message}
+                </li>
+              ))}
+            </ul>
+          </section>
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Adds an internal **Ops control tower** for NeuFin: unified snapshot of AI usage accounts (multi-provider model with explicit sync source/confidence), optional GitHub and Vercel adapters, Railway placeholder, in-process API error hints, integrations matrix, and manual overrides via `OPS_CONTROL_TOWER_MANUAL_JSON`.

## Backend
- New `GET /api/admin/control-tower` (admin JWT only), 60s in-memory cache
- New `neufin-backend/services/ops_control_tower.py`
- Optional settings: `OPS_GITHUB_TOKEN`, `OPS_GITHUB_REPO`, `OPS_VERCEL_*`, `OPS_RAILWAY_TOKEN`, `OPS_CONTROL_TOWER_MANUAL_JSON`

## Web
- `/admin/ops` — Control tower UI (Overview, AI usage, Repo, Deployments, Errors, Integrations, Audit)
- Next.js proxy: `/api/admin/control-tower`
- Nav + overview quick link

## Deploy
After merge to **main**, Vercel and Railway deploy from branch; GitHub Actions run **CI Backend** + **CI Web** on the PR, then **Post-Deploy Web** and **Post-Deploy Backend** on push to main.

## Checklist
- [x] `ruff`, `black`, `pytest` (backend)
- [x] `npm run build` (web)

Made with [Cursor](https://cursor.com)