### PR TITLE
fix: sanitize implication payloads at source and normalize article rendering

### DIFF
--- a/neufin-backend/routers/research.py
+++ b/neufin-backend/routers/research.py
@@ -13,6 +13,7 @@ Endpoints:
 
 from __future__ import annotations
 
+import ast
 import json
 import math
 import random
@@ -39,6 +40,66 @@ logger = structlog.get_logger("neufin.research")
 router = APIRouter(prefix="/api/research", tags=["research"])
 
 
+def sanitize_implication(raw: Any) -> dict[str, str]:
+    """Convert any implication format to a clean dict."""
+    if isinstance(raw, dict):
+        horizon = str(raw.get("time_horizon", raw.get("horizon", "")) or "").replace(
+            "_", " "
+        )
+        severity = str(
+            raw.get("severity", raw.get("priority", "MEDIUM")) or "MEDIUM"
+        ).upper()
+        if severity not in {"HIGH", "MEDIUM", "LOW", "INFO"}:
+            severity = "INFO"
+        return {
+            "action": str(raw.get("action", raw.get("text", "")) or ""),
+            "rationale": str(raw.get("rationale", raw.get("why", "")) or ""),
+            "time_horizon": horizon,
+            "severity": severity,
+        }
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+            return sanitize_implication(parsed)
+        except (json.JSONDecodeError, ValueError, TypeError):
+            pass
+        try:
+            parsed = ast.literal_eval(raw)
+            return sanitize_implication(parsed)
+        except (ValueError, SyntaxError):
+            pass
+        return {
+            "action": raw,
+            "rationale": "",
+            "time_horizon": "",
+            "severity": "INFO",
+        }
+    return {
+        "action": str(raw),
+        "rationale": "",
+        "time_horizon": "",
+        "severity": "INFO",
+    }
+
+
+def _sanitize_structured_implications(data: dict[str, Any]) -> dict[str, Any]:
+    """Normalize implication fields on structured research payloads."""
+    out = dict(data)
+
+    raw_implications = out.get("portfolio_implications")
+    if isinstance(raw_implications, list):
+        out["portfolio_implications"] = [
+            sanitize_implication(item) for item in raw_implications
+        ]
+    elif raw_implications:
+        out["portfolio_implications"] = [sanitize_implication(raw_implications)]
+
+    if out.get("recommended_action") is not None:
+        out["recommended_action"] = sanitize_implication(out.get("recommended_action"))
+
+    return out
+
+
 def _dict_to_markdown(data: dict) -> str:
     """Convert a structured research note dict to clean markdown prose.
 
@@ -54,10 +115,32 @@ def _dict_to_markdown(data: dict) -> str:
             return
         lines.append(f"## {heading}\n")
         if isinstance(value, str):
-            lines.append(value.strip())
+            if heading in ("Portfolio Implications", "Recommended Action"):
+                item = sanitize_implication(value)
+                details = [item["action"]]
+                if item["rationale"]:
+                    details.append(f"Why: {item['rationale']}")
+                if item["time_horizon"]:
+                    details.append(f"Horizon: {item['time_horizon']}")
+                if item["severity"]:
+                    details.append(f"Severity: {item['severity']}")
+                lines.append(f"- {' — '.join([d for d in details if d])}")
+            else:
+                lines.append(value.strip())
         elif isinstance(value, list):
             for item in value:
                 if isinstance(item, dict):
+                    if heading in ("Portfolio Implications", "Recommended Action"):
+                        normalized = sanitize_implication(item)
+                        details = [normalized["action"]]
+                        if normalized["rationale"]:
+                            details.append(f"Why: {normalized['rationale']}")
+                        if normalized["time_horizon"]:
+                            details.append(f"Horizon: {normalized['time_horizon']}")
+                        if normalized["severity"]:
+                            details.append(f"Severity: {normalized['severity']}")
+                        lines.append(f"- {' — '.join([d for d in details if d])}")
+                        continue
                     # Flatten common dict shapes
                     parts = []
                     for k in (
@@ -71,7 +154,11 @@ def _dict_to_markdown(data: dict) -> str:
                         if item.get(k):
                             parts.append(str(item[k]).strip())
                     support = item.get("data_support") or item.get("evidence") or ""
-                    bullet = " — ".join(parts) if parts else str(item)
+                    bullet = (
+                        " — ".join(parts)
+                        if parts
+                        else json.dumps(item, ensure_ascii=False)
+                    )
                     lines.append(f"- {bullet}")
                     if support:
                         lines.append(f"  *{support}*")
@@ -893,7 +980,7 @@ async def get_blog_note(slug: str):
     note_slug = str(note.get("slug") or "").strip() or slugify(title)
     content = note.get("content") or note.get("body") or note.get("full_content") or ""
     if isinstance(content, dict):
-        content = _dict_to_markdown(content)
+        content = _dict_to_markdown(_sanitize_structured_implications(content))
     elif isinstance(content, str):
         # Content might be a JSON-encoded dict stored as a string
         stripped = content.strip()
@@ -901,7 +988,9 @@ async def get_blog_note(slug: str):
             try:
                 parsed = json.loads(stripped)
                 if isinstance(parsed, dict):
-                    content = _dict_to_markdown(parsed)
+                    content = _dict_to_markdown(
+                        _sanitize_structured_implications(parsed)
+                    )
             except (json.JSONDecodeError, ValueError):
                 pass
     else:
@@ -988,6 +1077,10 @@ async def get_note(note_id: str, user: JWTUser = Depends(get_current_user)):
                 note["full_content"] = json.loads(note["full_content"])
             except (json.JSONDecodeError, TypeError):
                 pass
+        if isinstance(note.get("full_content"), dict):
+            note["full_content"] = _sanitize_structured_implications(
+                note["full_content"]
+            )
 
         return note
     except HTTPException:

--- a/neufin-backend/services/research/synthesiser.py
+++ b/neufin-backend/services/research/synthesiser.py
@@ -14,6 +14,7 @@ Also callable on-demand via POST /api/research/generate.
 
 from __future__ import annotations
 
+import ast
 import json
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -136,6 +137,79 @@ NOTE_TYPE_INSTRUCTIONS = {
 }
 
 
+def _sanitize_implication(raw: Any) -> dict[str, str]:
+    """Normalize implication payloads from dict / JSON string / Python dict string."""
+    fallback = {
+        "action": "",
+        "rationale": "",
+        "time_horizon": "",
+        "severity": "INFO",
+    }
+    if raw is None:
+        return fallback
+
+    if isinstance(raw, dict):
+        horizon = str(raw.get("time_horizon", raw.get("horizon", "")) or "").replace(
+            "_", " "
+        )
+        severity = str(
+            raw.get("severity", raw.get("priority", "MEDIUM")) or "MEDIUM"
+        ).upper()
+        if severity not in {"HIGH", "MEDIUM", "LOW", "INFO"}:
+            severity = "INFO"
+        return {
+            "action": str(raw.get("action", raw.get("text", "")) or ""),
+            "rationale": str(raw.get("rationale", raw.get("why", "")) or ""),
+            "time_horizon": horizon,
+            "severity": severity,
+        }
+
+    if isinstance(raw, str):
+        text = raw.strip()
+        if not text:
+            return fallback
+        try:
+            return _sanitize_implication(json.loads(text))
+        except (json.JSONDecodeError, TypeError, ValueError):
+            pass
+        try:
+            return _sanitize_implication(ast.literal_eval(text))
+        except (ValueError, SyntaxError):
+            return {
+                "action": text,
+                "rationale": "",
+                "time_horizon": "",
+                "severity": "INFO",
+            }
+
+    return {
+        "action": str(raw),
+        "rationale": "",
+        "time_horizon": "",
+        "severity": "INFO",
+    }
+
+
+def _sanitize_implication_fields(payload: dict[str, Any]) -> dict[str, Any]:
+    """Ensure implication-like fields are always clean dict/list structures."""
+    out = dict(payload)
+
+    raw_implications = out.get("portfolio_implications")
+    if isinstance(raw_implications, list):
+        out["portfolio_implications"] = [
+            _sanitize_implication(item) for item in raw_implications
+        ]
+    elif raw_implications:
+        out["portfolio_implications"] = [_sanitize_implication(raw_implications)]
+    else:
+        out["portfolio_implications"] = []
+
+    if out.get("recommended_action") is not None:
+        out["recommended_action"] = _sanitize_implication(out.get("recommended_action"))
+
+    return out
+
+
 async def generate_research_note(
     note_type: str = "macro_outlook",
     context_days: int = 7,
@@ -205,6 +279,8 @@ Return ONLY valid JSON — no markdown, no preamble:
     except Exception as exc:
         logger.error("synthesiser.ai_failed", error=str(exc))
         raise
+
+    result = _sanitize_implication_fields(result)
 
     # Extract fields with safe defaults
     title: str = result.get(

--- a/neufin-web/components/landing/HomeLandingPage.tsx
+++ b/neufin-web/components/landing/HomeLandingPage.tsx
@@ -271,137 +271,131 @@ export default function HomeLandingPage({
 
       <main className="flex-1">
         {/* Hero */}
-        <section className="relative flex min-h-screen items-center overflow-hidden bg-white pt-16">
-          <div
-            className="landing-animated-grid pointer-events-none absolute inset-0 z-0 opacity-[0.32]"
-            aria-hidden
-          />
-          <div
-            className="pointer-events-none absolute right-1/4 top-1/4 z-0 h-[600px] w-[600px] rounded-full bg-[#1EB8CC]/5 blur-3xl"
-            aria-hidden
-          />
-          <div
-            className="pointer-events-none absolute bottom-1/4 left-1/4 z-0 h-[400px] w-[400px] rounded-full bg-[#8B5CF6]/4 blur-3xl"
-            aria-hidden
-          />
+        <section className="relative min-h-screen flex items-center bg-[#050A14] pt-20 pb-16 overflow-hidden">
+          <div className="absolute inset-0 pointer-events-none" aria-hidden>
+            <div className="absolute top-1/3 left-1/4 w-96 h-96 bg-cyan-500/5 rounded-full blur-3xl" />
+            <div className="absolute top-1/2 right-1/4 w-80 h-80 bg-blue-500/5 rounded-full blur-3xl" />
+          </div>
 
-          <div className="relative z-10 mx-auto max-w-7xl px-6 py-24">
-            <div className="grid grid-cols-1 items-center gap-16 lg:grid-cols-2">
-              <div className="min-w-0 max-w-3xl">
-                <motion.div
-                  initial={{ opacity: 0, y: 16 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.5 }}
-                  className="mb-8 inline-flex items-center gap-2.5 rounded-full border border-primary/30 bg-lp-accent-soft px-4 py-2"
-                >
-                  <span className="relative flex h-2.5 w-2.5">
-                    <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary opacity-75" />
-                    <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-primary" />
+          <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 w-full">
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-16 items-center">
+              <div className="flex flex-col gap-5">
+                <div className="inline-flex">
+                  <span
+                    style={{
+                      fontSize: "11px",
+                      fontWeight: 600,
+                      letterSpacing: "0.12em",
+                      textTransform: "uppercase",
+                      color: "#22d3ee",
+                      lineHeight: 1,
+                    }}
+                  >
+                    Behavioral Finance Intelligence Platform
                   </span>
-                  <span className="text-xs font-bold uppercase tracking-widest text-primary">
-                    Live · Portfolio Intelligence
-                  </span>
-                </motion.div>
+                </div>
 
-                <motion.h1
-                  initial={{ opacity: 0, y: 24 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.6, delay: 0.1 }}
-                  className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight text-white leading-[1.1]"
+                <h1
+                  style={{
+                    fontSize: "clamp(2rem, 4.5vw, 3rem)",
+                    fontWeight: 700,
+                    lineHeight: 1.1,
+                    letterSpacing: "-0.02em",
+                    color: "#ffffff",
+                    margin: 0,
+                  }}
                 >
-                  <span className="text-xs font-semibold tracking-widest text-teal-400 uppercase mb-3 block">
-                    The Behavioral Finance Intelligence Layer for Serious Wealth Professionals
-                  </span>
                   7 AI agents.
                   <br />
                   One portfolio.
                   <br />
-                  <span className="text-primary">60 seconds.</span>
-                </motion.h1>
+                  60 seconds.
+                </h1>
 
-                <motion.p
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.5, delay: 0.16 }}
-                  className="mb-4 text-[clamp(16px,2vw,18px)] font-normal text-gray-400"
-                >
-                  IC-grade analysis. 47 behavioral biases. White-labeled output.
-                  MAS · MiFID II · GDPR aligned.
-                </motion.p>
-
-                <motion.p
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.5, delay: 0.2 }}
-                  className="text-base sm:text-lg text-gray-300 max-w-2xl leading-relaxed mt-4"
+                <p
+                  style={{
+                    fontSize: "clamp(0.95rem, 1.8vw, 1.1rem)",
+                    lineHeight: 1.7,
+                    color: "#94a3b8",
+                    margin: 0,
+                    maxWidth: "520px",
+                  }}
                 >
                   Upload your portfolio. Our 7-agent AI swarm delivers a
                   complete Investment Committee briefing — behavioral biases,
                   regime analysis, tax recommendations, alpha signals, and a
                   white-labeled IC memo.
-                </motion.p>
+                </p>
 
-                <HeroTrustStrip />
-
-                <motion.div
-                  initial={{ opacity: 0, y: 16 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.5, delay: 0.3 }}
-                  className="mb-14 flex flex-wrap gap-4"
-                >
-                  <Link href="/upload" className="group lp-btn-primary shadow-[0_4px_24px_rgba(30,184,204,0.35)] hover:shadow-[0_6px_32px_rgba(30,184,204,0.45)]">
-                    Analyze My Portfolio Free
-                    <svg
-                      className="h-4 w-4 transition-transform group-hover:translate-x-1"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={2.5}
-                      aria-hidden
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M13 7l5 5m0 0l-5 5m5-5H6"
-                      />
-                    </svg>
-                  </Link>
-                  <Link href="#demo" className="lp-btn-secondary">
-                    Watch 60-second demo
-                  </Link>
-                </motion.div>
-
-                <ConversionHierarchyBar />
-
-                <motion.div
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  transition={{ duration: 0.5, delay: 0.45 }}
-                  className="flex flex-wrap items-center gap-6 text-sm text-lp-muted"
-                >
+                <div style={{ display: "flex", flexWrap: "wrap", gap: "8px", marginTop: "4px" }}>
                   {[
-                    "14-day free trial",
-                    "No credit card required",
-                    "MAS · GDPR · MiFID II aligned",
-                    "SOC 2 in progress",
-                  ].map((t, i) => (
-                    <span key={i} className="flex items-center gap-2">
-                      <svg
-                        className="h-3.5 w-3.5 flex-shrink-0 text-[#22C55E]"
-                        fill="currentColor"
-                        viewBox="0 0 20 20"
-                        aria-hidden
-                      >
-                        <path
-                          fillRule="evenodd"
-                          d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                          clipRule="evenodd"
-                        />
-                      </svg>
-                      {t}
+                    "IC-grade analysis",
+                    "47 behavioral biases",
+                    "White-labeled output",
+                    "MAS · MiFID II · GDPR aligned",
+                  ].map((tag) => (
+                    <span
+                      key={tag}
+                      style={{
+                        fontSize: "11px",
+                        fontWeight: 500,
+                        color: "#64748b",
+                        background: "#0f172a",
+                        border: "1px solid #1e293b",
+                        borderRadius: "4px",
+                        padding: "4px 10px",
+                        letterSpacing: "0.02em",
+                      }}
+                    >
+                      {tag}
                     </span>
                   ))}
-                </motion.div>
+                </div>
+
+                <div style={{ display: "flex", gap: "12px", flexWrap: "wrap", marginTop: "8px" }}>
+                  <Link
+                    href="/upload"
+                    style={{
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: "8px",
+                      background: "#06b6d4",
+                      color: "#000000",
+                      fontWeight: 700,
+                      fontSize: "14px",
+                      padding: "12px 24px",
+                      borderRadius: "8px",
+                      textDecoration: "none",
+                      letterSpacing: "0.01em",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    Analyze My Portfolio — Free →
+                  </Link>
+                  <Link
+                    href="#demo"
+                    style={{
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: "8px",
+                      background: "transparent",
+                      color: "#94a3b8",
+                      fontWeight: 500,
+                      fontSize: "14px",
+                      padding: "12px 24px",
+                      borderRadius: "8px",
+                      border: "1px solid #1e293b",
+                      textDecoration: "none",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    Watch 60-second demo
+                  </Link>
+                </div>
+
+                <p style={{ fontSize: "12px", color: "#475569", margin: 0 }}>
+                  14-day free trial · No credit card required · MAS · GDPR · MiFID II aligned
+                </p>
               </div>
 
               <div className="relative hidden min-w-0 flex-col gap-6 lg:flex">

--- a/neufin-web/components/research/ResearchArticle.tsx
+++ b/neufin-web/components/research/ResearchArticle.tsx
@@ -3,7 +3,6 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
-import { ActionCard } from "@/components/ActionCard";
 
 const researchSchema = {
   ...defaultSchema,
@@ -40,6 +39,174 @@ export type ResearchArticleProps = {
   implicationItems?: Array<string | object>;
   suggestedAction?: string | object | null;
 };
+
+// Safe implication parser — handles Python dicts, JSON strings, and plain text.
+function safeParseImplication(raw: unknown): {
+  action: string;
+  rationale: string;
+  horizon: string;
+  severity: "HIGH" | "MEDIUM" | "LOW" | "INFO";
+} {
+  const fallback = {
+    action: "",
+    rationale: "",
+    horizon: "",
+    severity: "INFO" as const,
+  };
+  if (!raw) return fallback;
+
+  if (typeof raw === "object" && !Array.isArray(raw)) {
+    const r = raw as Record<string, unknown>;
+    const severityRaw = String(
+      r.severity ?? r.priority ?? "MEDIUM",
+    ).toUpperCase();
+    const severity =
+      severityRaw === "HIGH" || severityRaw === "MEDIUM" || severityRaw === "LOW"
+        ? severityRaw
+        : "INFO";
+    return {
+      action: String(r.action ?? r.text ?? r.signal ?? ""),
+      rationale: String(r.rationale ?? r.why ?? r.reason ?? ""),
+      horizon: String(r.time_horizon ?? r.horizon ?? r.timeframe ?? ""),
+      severity,
+    };
+  }
+
+  if (typeof raw !== "string") {
+    return { ...fallback, action: String(raw) };
+  }
+
+  let cleaned = raw.trim();
+  cleaned = cleaned
+    .replace(/'/g, '"')
+    .replace(/([{,]\s*)"(\w+)"\s*:/g, '$1"$2":')
+    .replace(/:\s*"([^"]*)"([,}])/g, ':"$1"$2');
+
+  try {
+    const parsed = JSON.parse(cleaned) as Record<string, unknown>;
+    const severityRaw = String(
+      parsed.severity ?? parsed.priority ?? "MEDIUM",
+    ).toUpperCase();
+    const severity =
+      severityRaw === "HIGH" || severityRaw === "MEDIUM" || severityRaw === "LOW"
+        ? severityRaw
+        : "INFO";
+    return {
+      action: String(parsed.action ?? parsed.text ?? raw),
+      rationale: String(parsed.rationale ?? parsed.why ?? ""),
+      horizon: String(parsed.time_horizon ?? parsed.horizon ?? ""),
+      severity,
+    };
+  } catch {
+    const actionMatch = raw.match(/['"]action['"]\s*:\s*['"]([^'"]+)['"]/i);
+    const rationaleMatch = raw.match(
+      /['"]rationale['"]\s*:\s*['"]([^'"]+)['"]/i,
+    );
+    return {
+      action: actionMatch ? actionMatch[1] : raw.replace(/[{}']/g, "").trim(),
+      rationale: rationaleMatch ? rationaleMatch[1] : "",
+      horizon: "",
+      severity: "INFO",
+    };
+  }
+}
+
+function ImplicationCard({ raw }: { raw: unknown }) {
+  const item = safeParseImplication(raw);
+  if (!item.action) return null;
+
+  const colors = {
+    HIGH: {
+      border: "#ef4444",
+      bg: "rgba(239,68,68,0.06)",
+      badge: "rgba(239,68,68,0.15)",
+      text: "#f87171",
+    },
+    MEDIUM: {
+      border: "#f59e0b",
+      bg: "rgba(245,158,11,0.06)",
+      badge: "rgba(245,158,11,0.15)",
+      text: "#fbbf24",
+    },
+    LOW: {
+      border: "#22c55e",
+      bg: "rgba(34,197,94,0.06)",
+      badge: "rgba(34,197,94,0.15)",
+      text: "#4ade80",
+    },
+    INFO: {
+      border: "#22d3ee",
+      bg: "rgba(34,211,238,0.06)",
+      badge: "rgba(34,211,238,0.15)",
+      text: "#67e8f9",
+    },
+  };
+  const c = colors[item.severity] || colors.INFO;
+
+  return (
+    <div
+      style={{
+        borderLeft: `3px solid ${c.border}`,
+        background: c.bg,
+        borderRadius: "0 6px 6px 0",
+        padding: "12px 16px",
+        margin: "10px 0",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "8px",
+          marginBottom: "6px",
+        }}
+      >
+        <span
+          style={{
+            fontSize: "10px",
+            fontWeight: 700,
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+            background: c.badge,
+            color: c.text,
+            padding: "2px 8px",
+            borderRadius: "3px",
+          }}
+        >
+          {item.severity}
+        </span>
+        {item.horizon && (
+          <span style={{ fontSize: "11px", color: "#64748b" }}>
+            ⏱ {item.horizon.replace(/_/g, " ")}
+          </span>
+        )}
+      </div>
+      <p
+        style={{
+          fontSize: "14px",
+          color: "#e2e8f0",
+          fontWeight: 500,
+          margin: "0 0 4px 0",
+          lineHeight: 1.5,
+        }}
+      >
+        {item.action}
+      </p>
+      {item.rationale && (
+        <p
+          style={{
+            fontSize: "12px",
+            color: "#64748b",
+            margin: 0,
+            lineHeight: 1.5,
+          }}
+        >
+          Why: {item.rationale}
+        </p>
+      )}
+    </div>
+  );
+}
 
 function displayRegime(regime: string | null | undefined) {
   if (!regime) return "Neutral";
@@ -229,14 +396,23 @@ export function ResearchArticle({
 
         {implicationItems.length > 0 || suggestedAction ? (
           <section className="mb-8 rounded-md border border-border bg-surface p-5">
-            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              Actionable Implications
-            </p>
-            <div className="mt-3">
+            <div style={{ marginTop: "24px" }}>
+              <h3
+                style={{
+                  fontSize: "11px",
+                  fontWeight: 700,
+                  letterSpacing: "0.1em",
+                  textTransform: "uppercase",
+                  color: "#475569",
+                  marginBottom: "12px",
+                }}
+              >
+                Implication Actions
+              </h3>
               {implicationItems.map((item, index) => (
-                <ActionCard key={index} raw={item} />
+                <ImplicationCard key={index} raw={item} />
               ))}
-              {suggestedAction ? <ActionCard raw={suggestedAction} /> : null}
+              {suggestedAction ? <ImplicationCard raw={suggestedAction} /> : null}
             </div>
           </section>
         ) : null}


### PR DESCRIPTION
Summary

Implements Nuclear Prompt 5 backend source sanitization and carries forward Nuclear Prompt 4 research article rendering hardening.

Backend source-level fix

1) Synthesiser sanitization at generation and storage
- File: neufin-backend/services/research/synthesiser.py
- Added implication sanitizer to normalize:
  - dict payloads
  - JSON strings
  - Python dict strings via ast.literal_eval
- Ensures implication fields persist as clean objects (never repr strings)
- Normalizes time_horizon to human-readable format (example: 1_week to 1 week)
- Normalizes severity to HIGH, MEDIUM, LOW, or INFO

2) Router sanitization before response
- File: neufin-backend/routers/research.py
- Added sanitize_implication plus structured implication normalization helper
- Applied before markdown conversion and before returning full note payloads
- Removed dict-string fallback behavior in markdown implication rendering

Frontend article safety
- File: neufin-web/components/research/ResearchArticle.tsx
- Uses safe parser and implication card rendering for implication entries

Prompt 6 status
- app/page.tsx is a wrapper-only file with no h2/h3/p typography targets, so this was a no-op by constraint.

Validation
- backend ruff check: passed
- backend black check: passed

Commit
- 61487bb
