### PR TITLE
test(dna): stabilize multipart upload CI

### DIFF
--- a/neufin-backend/services/market_cache.py
+++ b/neufin-backend/services/market_cache.py
@@ -165,11 +165,27 @@ def get_closes(symbol: str, days: int) -> pd.Series | None:
             if (
                 row is not None and row.data
             ):  # FIXED: guard against None response from maybe_single()
-                series = _json_to_series(row.data["payload"])
-                logger.debug("market_cache.supabase_hit", key=k)
-                # Backfill Redis so the next hit is faster
-                _redis_set(k, row.data["payload"])
-                return series
+                data = row.data
+                if not isinstance(data, dict):
+                    logger.warning(
+                        "market_cache.supabase_payload_invalid",
+                        key=k,
+                        payload_type=type(data).__name__,
+                    )
+                else:
+                    payload = data.get("payload")
+                    if not isinstance(payload, str | bytes | bytearray):
+                        logger.warning(
+                            "market_cache.supabase_payload_invalid",
+                            key=k,
+                            payload_type=type(payload).__name__,
+                        )
+                    else:
+                        series = _json_to_series(payload)
+                        logger.debug("market_cache.supabase_hit", key=k)
+                        # Backfill Redis so the next hit is faster
+                        _redis_set(k, payload)
+                        return series
         except Exception as e:
             logger.warning("market_cache.supabase_get_error", error=str(e))
 

--- a/neufin-backend/tests/test_analyze_dna_multipart.py
+++ b/neufin-backend/tests/test_analyze_dna_multipart.py
@@ -26,7 +26,6 @@ def client():
         patch(
             "main.get_price_with_fallback",
         ) as mock_price,
-        patch("services.ai_router.get_ai_analysis", new_callable=AsyncMock) as mock_ai,
         patch("services.analytics.track", new_callable=AsyncMock),
     ):
         from services.market_cache import PriceResult
@@ -35,14 +34,6 @@ def client():
             return PriceResult(symbol=sym.upper(), price=180.0, status="live")
 
         mock_price.side_effect = _price
-
-        # ai_router returns a fixed analysis dict
-        mock_ai.return_value = {
-            "investor_type": "Diversified Strategist",
-            "strengths": ["s1", "s2", "s3"],
-            "weaknesses": ["w1", "w2"],
-            "recommendation": "Hold steady.",
-        }
 
         # Supabase insert returns a minimal result
         insert_result = MagicMock()
@@ -60,13 +51,28 @@ def client():
 @pytest.mark.parametrize("field_name", FIELD_NAMES)
 def test_any_field_name_accepted(client, field_name):
     """POST with field name '{field_name}' must not return 422."""
-    response = client.post(
-        "/api/analyze-dna",
-        files={field_name: ("portfolio.csv", io.BytesIO(SAMPLE_CSV), "text/csv")},
-    )
+    mock_response = {
+        "analysis": "Simulated real-time analysis",
+        "status": "success",
+        "investor_type": "Diversified Strategist",
+        "strengths": ["Diversified across mega-cap equities"],
+        "weaknesses": ["Monitor concentration"],
+        "recommendation": "Hold steady.",
+    }
+
+    with patch("main.get_ai_analysis", new_callable=AsyncMock) as mock_ai:
+        mock_ai.return_value = mock_response
+        response = client.post(
+            "/api/analyze-dna",
+            files={field_name: ("portfolio.csv", io.BytesIO(SAMPLE_CSV), "text/csv")},
+        )
+
     assert (
         response.status_code != 422
     ), f"Field name '{field_name}' returned 422: {response.text}"
+    assert response.status_code == 200
+    assert "analysis" in response.json()
+    mock_ai.assert_called_once()
 
 
 def test_no_file_returns_422(client):


### PR DESCRIPTION
## Summary
- patch multipart upload test at main.get_ai_analysis, the symbol used by the FastAPI route
- return a deterministic successful AI analysis payload so CI does not depend on external provider keys
- guard market_cache Supabase reads against MagicMock payloads before json.loads, allowing fallback tiers to continue

## Tests
- pytest tests/test_analyze_dna_multipart.py
- pytest tests/unit tests/test_analyze_dna_multipart.py
- ruff check tests/test_analyze_dna_multipart.py services/market_cache.py
- black --check tests/test_analyze_dna_multipart.py services/market_cache.py