### PR TITLE
fix(upload): eliminate ERR_NAME_NOT_RESOLVED and normalize 402 errors on /upload

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,12 @@ SUPABASE_SERVICE_ROLE_KEY=YOUR_SUPABASE_SERVICE_ROLE_KEY_HERE
 
 # ── Site / App URLs ───────────────────────────────────────────────────────────
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
-NEXT_PUBLIC_API_URL=https://YOUR_RAILWAY_BACKEND_URL_HERE
+# WARNING: Do NOT set NEXT_PUBLIC_API_URL to the Railway URL in Vercel production.
+# Leave empty so the browser uses relative /api/* paths (proxied server-side).
+# See neufin-web/.env.example for the full explanation.
+NEXT_PUBLIC_API_URL=
+# Server-only Railway target — set this in Vercel dashboard (no NEXT_PUBLIC_ prefix).
+RAILWAY_API_URL=https://YOUR_RAILWAY_BACKEND_URL_HERE
 
 # ── Backend API (neufin-backend) ──────────────────────────────────────────────
 PORT=8000

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -102,10 +102,15 @@ Set in Vercel dashboard → neufin-web → Settings → Environment Variables:
 ```
 NEXT_PUBLIC_SUPABASE_URL=https://<project>.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=<anon_key>
-NEXT_PUBLIC_API_BASE_URL=https://neufin101-production.up.railway.app
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_...
 STRIPE_SECRET_KEY=sk_live_...
 NEXT_PUBLIC_SENTRY_DSN=https://...
+
+# Server-only — proxies /api/* to Railway.  No NEXT_PUBLIC_ prefix.
+# DO NOT set NEXT_PUBLIC_API_URL to the Railway URL; leave it unset or empty.
+# Setting it to the Railway URL bakes that domain into the JS bundle and causes
+# ERR_NAME_NOT_RESOLVED for users on networks that block *.up.railway.app.
+RAILWAY_API_URL=https://neufin101-production.up.railway.app
 ```
 
 ### Deploy to Production

--- a/neufin-web/.env.example
+++ b/neufin-web/.env.example
@@ -4,15 +4,20 @@ NEXT_PUBLIC_SUPABASE_URL=https://<your-project-ref>.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=<your-supabase-anon-key>
 
 # ── Backend API ───────────────────────────────────────────────────────────────
-# Browser bundle — used by client-side fetch calls.
-#   Local dev:  http://localhost:8080
-#   Production (Vercel): set to your Vercel domain (e.g. https://neufin-web.vercel.app)
-#   so calls go to the same-origin Vercel proxy and never hit Railway directly.
-NEXT_PUBLIC_API_URL=http://localhost:8080
+# NEXT_PUBLIC_API_URL — browser-bundle base for general API calls.
+#   Leave EMPTY in Vercel production so all /api/* calls stay same-origin and
+#   are proxied server-side to Railway.  Setting this to the Railway URL causes
+#   browsers to call Railway directly, which breaks on networks that block
+#   *.up.railway.app (corporate firewalls, regional DNS gaps → ERR_NAME_NOT_RESOLVED).
+#
+#   Local dev: set to http://localhost:8000 if running the backend locally,
+#   or leave empty and set RAILWAY_API_URL below to use the live backend.
+NEXT_PUBLIC_API_URL=
 
-# Server-only — used by next.config.js rewrite destination (never sent to browser).
-# Always point this at Railway. Vercel edge proxy forwards /api/* here.
-# Set this in the Vercel dashboard under Environment Variables (not NEXT_PUBLIC_*).
+# RAILWAY_API_URL — server-only.  Used by next.config.js rewrites and Next.js
+# API route proxies (e.g. /api/analyze-dna).  NEVER use NEXT_PUBLIC_ here —
+# this must NOT be embedded in the browser bundle.
+# Set in the Vercel dashboard → Settings → Environment Variables (not in .env files).
 RAILWAY_API_URL=https://neufin101-production.up.railway.app
 
 # ── App URL ───────────────────────────────────────────────────────────────────

--- a/neufin-web/app/api/admin/leads/[leadId]/route.ts
+++ b/neufin-web/app/api/admin/leads/[leadId]/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 
-const BACKEND = process.env.NEXT_PUBLIC_API_URL ?? "";
+const BACKEND =
+  process.env.RAILWAY_API_URL ||
+  process.env.NEXT_PUBLIC_API_URL ||
+  "";
 export const dynamic = "force-dynamic";
 
 export async function PATCH(

--- a/neufin-web/app/api/admin/leads/route.ts
+++ b/neufin-web/app/api/admin/leads/route.ts
@@ -4,7 +4,10 @@
  */
 import { NextRequest, NextResponse } from "next/server";
 
-const BACKEND = process.env.NEXT_PUBLIC_API_URL ?? "";
+const BACKEND =
+  process.env.RAILWAY_API_URL ||
+  process.env.NEXT_PUBLIC_API_URL ||
+  "";
 
 export const dynamic = "force-dynamic";
 

--- a/neufin-web/app/api/admin/leads/stats/route.ts
+++ b/neufin-web/app/api/admin/leads/stats/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 
-const BACKEND = process.env.NEXT_PUBLIC_API_URL ?? "";
+const BACKEND =
+  process.env.RAILWAY_API_URL ||
+  process.env.NEXT_PUBLIC_API_URL ||
+  "";
 export const dynamic = "force-dynamic";
 
 export async function GET(req: NextRequest) {

--- a/neufin-web/app/api/admin/users/route.ts
+++ b/neufin-web/app/api/admin/users/route.ts
@@ -9,7 +9,10 @@ import { NextRequest, NextResponse } from "next/server";
 
 export const dynamic = "force-dynamic";
 
-const BACKEND = () => process.env.NEXT_PUBLIC_API_URL ?? "";
+const BACKEND = () =>
+  process.env.RAILWAY_API_URL ||
+  process.env.NEXT_PUBLIC_API_URL ||
+  "";
 
 function extractBearerToken(req: NextRequest): string {
   const auth = req.headers.get("authorization")?.trim();

--- a/neufin-web/app/api/analyze-dna/route.ts
+++ b/neufin-web/app/api/analyze-dna/route.ts
@@ -1,0 +1,103 @@
+import { NextRequest, NextResponse } from "next/server";
+import { bearerTokenFromRequest } from "@/lib/proxy";
+
+const RAILWAY_BASE =
+  process.env.RAILWAY_API_URL ||
+  "https://neufin101-production.up.railway.app";
+
+/**
+ * Proxy POST /api/analyze-dna → Railway.
+ *
+ * Why this exists instead of relying on the next.config.js fallback rewrite:
+ *   The rewrite runs on the server but only when NEXT_PUBLIC_API_URL is empty.
+ *   If NEXT_PUBLIC_API_URL is accidentally set to the Railway URL in Vercel,
+ *   the browser bundle calls Railway directly — which breaks on any network
+ *   that can't resolve *.up.railway.app (corporate proxies, regional DNS gaps).
+ *
+ *   This route always intercepts /api/analyze-dna at the Vercel edge, so the
+ *   browser never needs to reach Railway.  The Railway call is server→server.
+ *
+ * Multipart note: proxyToRailway() reads the body as text which destroys the
+ * multipart boundary. We must preserve the original Content-Type header
+ * (including boundary) and stream the body as-is.
+ */
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const contentType = req.headers.get("content-type") ?? "";
+  const bearerToken = bearerTokenFromRequest(req);
+
+  const forwardHeaders: Record<string, string> = {};
+  if (contentType) forwardHeaders["Content-Type"] = contentType;
+  if (bearerToken) forwardHeaders["Authorization"] = `Bearer ${bearerToken}`;
+
+  // Forward X-Forwarded-For so Railway can rate-limit guests by real IP
+  const xff = req.headers.get("x-forwarded-for");
+  if (xff) forwardHeaders["X-Forwarded-For"] = xff;
+
+  try {
+    const upstream = await fetch(`${RAILWAY_BASE}/api/analyze-dna`, {
+      method: "POST",
+      headers: forwardHeaders,
+      body: req.body,
+      // @ts-expect-error — duplex required for streaming request bodies in Node 18+
+      duplex: "half",
+      signal: AbortSignal.timeout(60_000),
+    });
+
+    const text = await upstream.text();
+    let data: unknown;
+    try {
+      data = JSON.parse(text);
+    } catch {
+      data = { raw: text };
+    }
+
+    // Normalize 402 detail so the browser always gets a consistent shape.
+    // The Python backend returns: { detail: { code, message, checkout_url?, upgrade_url? } }
+    // Flatten it so the frontend can read detail.message directly.
+    if (upstream.status === 402) {
+      const raw = data as Record<string, unknown>;
+      const detail =
+        typeof raw?.detail === "object" && raw.detail !== null
+          ? (raw.detail as Record<string, unknown>)
+          : null;
+
+      return NextResponse.json(
+        {
+          success: false,
+          error_code:
+            (detail?.code as string) ?? "SUBSCRIPTION_REQUIRED",
+          message:
+            (detail?.message as string) ??
+            "Subscription required to run this analysis.",
+          checkout_url:
+            (detail?.checkout_url as string) ??
+            (detail?.upgrade_url as string) ??
+            null,
+          upgrade_url: (detail?.upgrade_url as string) ?? "/pricing",
+        },
+        { status: 402 },
+      );
+    }
+
+    return NextResponse.json(data, { status: upstream.status });
+  } catch (err) {
+    console.error("[analyze-dna proxy] upstream error:", err);
+    // Distinguish DNS/network errors from Railway being up but erroring
+    const isNetworkError =
+      err instanceof TypeError &&
+      (String(err.message).includes("fetch failed") ||
+        String(err.message).includes("ENOTFOUND") ||
+        String(err.message).includes("network"));
+
+    return NextResponse.json(
+      {
+        success: false,
+        error_code: isNetworkError ? "BACKEND_UNAVAILABLE" : "PROXY_ERROR",
+        message: isNetworkError
+          ? "Analysis service is temporarily unreachable. Please try again in a moment."
+          : "An unexpected error occurred. Please try again.",
+      },
+      { status: 502 },
+    );
+  }
+}

--- a/neufin-web/app/api/developer/keys/[keyId]/route.ts
+++ b/neufin-web/app/api/developer/keys/[keyId]/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 
-const BACKEND = process.env.NEXT_PUBLIC_API_URL ?? "";
+const BACKEND =
+  process.env.RAILWAY_API_URL ||
+  process.env.NEXT_PUBLIC_API_URL ||
+  "";
 export const dynamic = "force-dynamic";
 
 export async function DELETE(

--- a/neufin-web/app/api/developer/keys/route.ts
+++ b/neufin-web/app/api/developer/keys/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 
-const BACKEND = process.env.NEXT_PUBLIC_API_URL ?? "";
+const BACKEND =
+  process.env.RAILWAY_API_URL ||
+  process.env.NEXT_PUBLIC_API_URL ||
+  "";
 export const dynamic = "force-dynamic";
 
 export async function GET(req: NextRequest) {

--- a/neufin-web/app/upload/page.tsx
+++ b/neufin-web/app/upload/page.tsx
@@ -4,7 +4,7 @@ import { Suspense, useState, useEffect, useRef, DragEvent, ChangeEvent } from "r
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { BrandLogo } from "@/components/BrandLogo";
-import { analyzeDNA } from "@/lib/api";
+import { analyzeDNA, SubscriptionRequiredError } from "@/lib/api";
 import { useAuth } from "@/lib/auth-context";
 import RefCapture from "@/components/RefCapture";
 import { trackEvent, EVENTS } from "@/components/Analytics";
@@ -102,6 +102,14 @@ export default function UploadPage() {
       capture("csv_upload_failed", {
         error_reason: e instanceof Error ? e.message : "unknown",
       });
+      if (e instanceof SubscriptionRequiredError) {
+        if (e.checkoutUrl) {
+          window.location.href = e.checkoutUrl;
+          return;
+        }
+        router.push(e.upgradeUrl);
+        return;
+      }
       setError(
         e instanceof Error ? e.message : "Analysis failed. Please try again.",
       );

--- a/neufin-web/lib/admin-backend-proxy.ts
+++ b/neufin-web/lib/admin-backend-proxy.ts
@@ -1,7 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 
 function backendBase(): string {
-  return process.env.NEXT_PUBLIC_API_URL ?? "";
+  return (
+    process.env.RAILWAY_API_URL ||
+    process.env.NEXT_PUBLIC_API_URL ||
+    ""
+  );
 }
 
 function extractBearerToken(req: NextRequest): string | null {
@@ -29,7 +33,7 @@ export async function proxyBackendJson(
     return NextResponse.json(
       {
         error: "server_misconfigured",
-        message: "NEXT_PUBLIC_API_URL is not set",
+        message: "RAILWAY_API_URL is not set",
       },
       { status: 503 },
     );

--- a/neufin-web/lib/api.ts
+++ b/neufin-web/lib/api.ts
@@ -105,9 +105,12 @@ export async function claimAnonymousPortfolio(
   }
   return res.json();
 }
-// Empty string = relative URL → routes through Next.js /api/* rewrite proxy to Railway.
-// In Vercel production, set NEXT_PUBLIC_API_URL=https://neufin-web.vercel.app so
-// client-side fetch calls hit the same-origin proxy. Do NOT point directly at Railway.
+// Leave NEXT_PUBLIC_API_URL empty (or unset) in Vercel production.
+// An empty string means all fetch calls use relative /api/* paths, which the
+// Next.js rewrite proxy (next.config.js fallback rules) forwards to Railway.
+// Never set this to the Railway URL in production — doing so bakes the Railway
+// hostname into the browser bundle, causing ERR_NAME_NOT_RESOLVED on networks
+// that block *.up.railway.app.  Set RAILWAY_API_URL (server-only) instead.
 const API = process.env.NEXT_PUBLIC_API_URL ?? "";
 
 /** Absolute origin for server-side fetch to this deployment (RSC / ISR). Relative `/api` can throw without a base. */

--- a/neufin-web/lib/api.ts
+++ b/neufin-web/lib/api.ts
@@ -323,20 +323,56 @@ export async function getSEAPulse(): Promise<SEAPulseResponse> {
 
 // ── DNA ───────────────────────────────────────────────────────────────────────
 
+export class SubscriptionRequiredError extends Error {
+  readonly checkoutUrl: string | null;
+  readonly upgradeUrl: string;
+  constructor(message: string, checkoutUrl: string | null, upgradeUrl = "/pricing") {
+    super(message);
+    this.name = "SubscriptionRequiredError";
+    this.checkoutUrl = checkoutUrl;
+    this.upgradeUrl = upgradeUrl;
+  }
+}
+
 export async function analyzeDNA(
   file: File,
   token?: string | null,
 ): Promise<DNAAnalysisResponse> {
   const form = new FormData();
   form.append("file", file);
-  const res = await fetch(`${API}/api/analyze-dna`, {
+  // Always use a relative URL so the call goes through the Vercel/Next.js proxy
+  // instead of hitting Railway directly from the browser.  Direct browser→Railway
+  // calls fail with ERR_NAME_NOT_RESOLVED on networks that block *.up.railway.app.
+  const res = await fetch("/api/analyze-dna", {
     method: "POST",
     body: form,
     headers: authHeaders(token),
   });
   if (!res.ok) {
-    const err = await res.json().catch(() => ({ detail: res.statusText }));
-    throw new Error(err.detail || "Analysis failed");
+    const err = await res.json().catch(() => ({} as Record<string, unknown>));
+    if (res.status === 402) {
+      const msg =
+        (err.message as string) ??
+        (typeof err.detail === "string" ? err.detail : null) ??
+        "Subscription required to run this analysis.";
+      const checkoutUrl =
+        (err.checkout_url as string | null) ??
+        (typeof err.detail === "object" && err.detail !== null
+          ? ((err.detail as Record<string, unknown>).checkout_url as string | null) ?? null
+          : null);
+      const upgradeUrl =
+        (err.upgrade_url as string) ??
+        (typeof err.detail === "object" && err.detail !== null
+          ? ((err.detail as Record<string, unknown>).upgrade_url as string) ?? "/pricing"
+          : "/pricing");
+      throw new SubscriptionRequiredError(msg, checkoutUrl ?? null, upgradeUrl);
+    }
+    const message =
+      typeof err.detail === "string"
+        ? err.detail
+        : (err.message as string | undefined) ??
+          "Analysis failed. Please try again.";
+    throw new Error(message);
   }
   return res.json();
 }

--- a/neufin-web/lib/env-check.ts
+++ b/neufin-web/lib/env-check.ts
@@ -7,7 +7,10 @@
 type EnvCheck = { key: string; value: string | undefined };
 
 const REQUIRED_PUBLIC: readonly EnvCheck[] = [
-  { key: "NEXT_PUBLIC_API_URL", value: process.env.NEXT_PUBLIC_API_URL },
+  // NEXT_PUBLIC_API_URL is intentionally optional — leave empty in production
+  // so all /api/* browser calls use relative paths (proxied by Vercel to Railway).
+  // Setting it to the Railway URL bakes that domain into the browser bundle and
+  // causes ERR_NAME_NOT_RESOLVED on networks that block *.up.railway.app.
   {
     key: "NEXT_PUBLIC_SUPABASE_URL",
     value: process.env.NEXT_PUBLIC_SUPABASE_URL,
@@ -24,7 +27,9 @@ const REQUIRED_PUBLIC: readonly EnvCheck[] = [
 ];
 
 const REQUIRED_SERVER: readonly EnvCheck[] = [
-  // Only checked server-side; never included in client bundle
+  // Server-only Railway target — proxies /api/* from Vercel to Railway.
+  // Must be set in Vercel dashboard without NEXT_PUBLIC_ prefix.
+  { key: "RAILWAY_API_URL", value: process.env.RAILWAY_API_URL },
   { key: "NEXT_PUBLIC_APP_URL", value: process.env.NEXT_PUBLIC_APP_URL },
 ];
 


### PR DESCRIPTION
## Summary

- **Root cause of ERR_NAME_NOT_RESOLVED**: `NEXT_PUBLIC_API_URL` was (or can be) set to the Railway URL in Vercel, baking `https://neufin101-production.up.railway.app` into the browser JS bundle. Users on corporate networks / ISPs with regional DNS gaps that block `*.up.railway.app` get a hard `ERR_NAME_NOT_RESOLVED` — the request never leaves the browser.
- **Root cause of 402**: The backend intentionally returns 402 when a user's trial is expired or their monthly analysis limit is reached. But the frontend `analyzeDNA` function was doing `new Error(err.detail)` where `err.detail` is an object → shows `"[object Object]"` instead of a human-readable message, and never offered to redirect to checkout.
- **Why owner couldn't reproduce**: Local `.env.local` pointed directly at Railway (which the owner's network resolves fine), and the owner's account is not in an expired/limit-reached state.

## Fixes applied

| # | File | Change |
|---|------|--------|
| 1 | `neufin-web/app/api/analyze-dna/route.ts` *(new)* | Next.js App Router proxy route — streams multipart to Railway **server-side**; browser never sees the Railway domain. Normalizes all 402s to `{ error_code, message, checkout_url, upgrade_url }`. |
| 2 | `neufin-web/lib/api.ts` | `analyzeDNA` now uses `/api/analyze-dna` (relative URL) so it always hits the Vercel proxy regardless of `NEXT_PUBLIC_API_URL`. Introduces `SubscriptionRequiredError` with `checkoutUrl`/`upgradeUrl` fields. |
| 3 | `neufin-web/app/upload/page.tsx` | Catches `SubscriptionRequiredError` and redirects to Stripe checkout URL (or `/pricing` fallback). |
| 4 | `neufin-web/.env.example`, `.env.example`, `docs/DEPLOYMENT.md` | Corrects the Vercel env var pattern: `RAILWAY_API_URL` (server-only) vs `NEXT_PUBLIC_API_URL` (leave empty in prod). Prevents future misconfiguration. |

## Post-merge action required

**In Vercel dashboard → neufin-web → Settings → Environment Variables:**

1. Set `RAILWAY_API_URL=https://neufin101-production.up.railway.app` *(server-only, no NEXT_PUBLIC prefix)*
2. Remove or clear `NEXT_PUBLIC_API_URL` (or set to empty string)

This is the config change that eliminates the browser→Railway direct call path for all users.

## Test plan

- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run build` — compiled successfully, `/upload` route included
- [x] `pytest tests/test_error_responses.py tests/test_analyze_dna_multipart.py` — 14 passed
- [ ] After merge + Vercel env fix: upload a CSV as a guest → should work without ERR_NAME_NOT_RESOLVED
- [ ] Upload as expired-trial user → should redirect to Stripe checkout
- [ ] Upload as limit-reached user → should redirect to /pricing

🤖 Generated with [Claude Code](https://claude.com/claude-code)